### PR TITLE
Rename AssociatePublicIPAddress parameter and make its description more accurate

### DIFF
--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -512,7 +512,7 @@ Parameters:
     Default: true
     AllowedValues: [true, false]
     ConstraintDescription: Must be 'true' or 'false'.
-    Description: Controls if the load balancer is deployed as internet-facing (visible to all on internet) or internal (private to VPC).
+    Description: Controls whether the load balancer should be visible to the internet (true) or only within the VPC (false).
     Type: String
   CustomDnsName:
     Default: ""

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -15,7 +15,7 @@ Metadata:
           - AccessCIDR
           - VPCCIDR
           - AvailabilityZones
-          - AssociatePublicIpAddress
+          - InternetFacingLoadBalancer
           - CustomDnsName
           - SSLCertificateARN
           - PrivateSubnet1CIDR
@@ -69,8 +69,6 @@ Metadata:
         default: AMI Options
       AvailabilityZones:
         default: Availability Zones
-      AssociatePublicIpAddress:
-        default: Assign public IP
       BitbucketProperties:
         default: Bitbucket properties
       BitbucketVersion:
@@ -131,6 +129,8 @@ Metadata:
         default: Home directory size
       HomeVolumeSnapshotId:
         default: Home volume snapshot ID to restore
+      InternetFacingLoadBalancer:
+        default: Make instance internet facing
       KeyPairName:
         default: Key Name
       PrivateSubnet1CIDR:
@@ -209,12 +209,6 @@ Parameters:
     Default: ''
     Description: A comma separated list of options to pass to the AMI
     Type: CommaDelimitedList
-  AssociatePublicIpAddress:
-    Default: true
-    AllowedValues: [true, false]
-    ConstraintDescription: Must be 'true' or 'false'.
-    Description: Controls if the EC2 instances are assigned a public IP address
-    Type: String
   BitbucketProperties:
     Default: ''
     Description: A comma-separated list of bitbucket properties in the form 'key1=value1, key2=value2, ...' Find documentation at https://confluence.atlassian.com/x/m5ZKLg
@@ -514,6 +508,12 @@ Parameters:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
     Description: The EC2 Key Pair to allow SSH access to the instances
     Type: AWS::EC2::KeyPair::KeyName
+  InternetFacingLoadBalancer:
+    Default: true
+    AllowedValues: [true, false]
+    ConstraintDescription: Must be 'true' or 'false'.
+    Description: Controls if the load balancer is deployed as internet-facing (visible to all on internet) or internal (private to VPC).
+    Type: String
   CustomDnsName:
     Default: ""
     Description: 'Use custom existing DNS name for your Data Center instance. Please note: you must own the domain and configure it to point at the load balancer.'
@@ -564,7 +564,7 @@ Resources:
         AMIOpts: !Join
           - ','
           - !Ref 'AMIOpts'
-        AssociatePublicIpAddress: !Ref 'AssociatePublicIpAddress'
+        InternetFacingLoadBalancer: !Ref 'InternetFacingLoadBalancer'
         BitbucketProperties: !Join
           - ','
           - !Ref 'BitbucketProperties'

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -456,7 +456,7 @@ Parameters:
     Default: true
     AllowedValues: [true, false]
     ConstraintDescription: Must be 'true' or 'false'.
-    Description: Controls if the load balancer is deployed as internet-facing (visible to all on internet) or internal (private to VPC).
+    Description: Controls whether the load balancer should be visible to the internet (true) or only within the VPC (false).
     Type: String
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -38,8 +38,8 @@ Metadata:
       - Label:
           default: Networking
         Parameters:
-          - AssociatePublicIpAddress
           - CidrBlock
+          - InternetFacingLoadBalancer
           - KeyPairName
           - CustomDnsName
           - SSLCertificateARN
@@ -62,8 +62,6 @@ Metadata:
           - DeploymentAutomationKeyName
 
     ParameterLabels:
-      AssociatePublicIpAddress:
-        default: Assign public IP
       BitbucketProperties:
         default: Bitbucket properties
       BitbucketVersion:
@@ -126,6 +124,8 @@ Metadata:
         default: Home volume snapshot ID to restore
       HomeVolumeType:
         default: Home directory volume type
+      InternetFacingLoadBalancer:
+        default: Make instance internet facing
       KeyPairName:
         default: Key Name *
       CustomDnsName:
@@ -134,12 +134,6 @@ Metadata:
         default: SSL Certificate ARN
 
 Parameters:
-  AssociatePublicIpAddress:
-    Default: true
-    AllowedValues: [true, false]
-    ConstraintDescription: Must be 'true' or 'false'.
-    Description: Controls if the EC2 instances are assigned a public IP address
-    Type: String
   BitbucketProperties:
     Default: ''
     Description: A comma-separated list of bitbucket properties in the form 'key1=value1, key2=value2, ...' Find documentation at https://confluence.atlassian.com/x/m5ZKLg
@@ -458,6 +452,12 @@ Parameters:
     AllowedValues: [General Purpose (SSD), Provisioned IOPS]
     ConstraintDescription: Must be 'General Purpose (SSD)' or 'Provisioned IOPS'.
     Type: String
+  InternetFacingLoadBalancer:
+    Default: true
+    AllowedValues: [true, false]
+    ConstraintDescription: Must be 'true' or 'false'.
+    Description: Controls if the load balancer is deployed as internet-facing (visible to all on internet) or internal (private to VPC).
+    Type: String
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
     Description: The EC2 Key Pair to allow SSH access to the instances
@@ -527,7 +527,7 @@ Conditions:
   SetDBMasterUserPassword:
     !And [!Not [!Equals [!Ref DBMasterUserPassword, '']], Condition: NotStandbyMode]
   UsePublicIp:
-    !Equals [!Ref AssociatePublicIpAddress, 'true']
+    !Equals [!Ref InternetFacingLoadBalancer, 'true']
 
 Mappings:
   AWSRegionArch2AMI:


### PR DESCRIPTION
Before this parameter said it made the EC2 instances publicly accessible which isn't true. It simply determines whether the load balancer is internet facing or internal. This is now more clear.