### PR TITLE
DCD-289: Fix linting

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -1,0 +1,7 @@
+templates:
+  - templates/*
+ignore_checks:
+  - E2504
+    # The check cannot handle this situation:
+    # Iops: !If [IsHomeProvisionedIops, !Ref HomeIops, !Ref "AWS::NoValue"]
+    # VolumeType: !If [IsHomeProvisionedIops, io1, gp2]

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -388,12 +388,12 @@ Parameters:
     MaxValue: 30000
     Type: Number
   DBMasterUserPassword:
-    AllowedPattern: '[a-zA-Z0-9]*'
-    ConstraintDescription: Must be at least 8 alphanumeric characters.
-    Description: Password for the master ('postgres') account.
-    MinLength: 8
+    AllowedPattern: '(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*'
+    ConstraintDescription: Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
+    Description: Password for the master ('postgres') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
+    NoEcho: True
     MaxLength: 128
-    NoEcho: true
+    MinLength: 8
     Type: String
   DBMultiAZ:
     Description: Whether to provision a multi-AZ RDS instance.
@@ -404,9 +404,9 @@ Parameters:
     ConstraintDescription: Must be 'true' or 'false'.
     Type: String
   DBPassword:
-    AllowedPattern: '[a-zA-Z0-9]*'
-    ConstraintDescription: If specified, must be at least 8 alphanumeric characters.
-    Description: Password for the Bitbucket user ('atlbitbucket') account. Max length of 128 characters. Not used if you have specified a Database snapshot ID.
+    AllowedPattern: '(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*'
+    ConstraintDescription: Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
+    Description: Password for the Bitbucket user ('atlbitbucket') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
     MaxLength: 128
     NoEcho: true
     Type: String

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -135,7 +135,7 @@ Metadata:
       PrivateSubnet2CIDR:
         default: AZ2 private IP address block
       PublicSubnet1CIDR:
-        default: AZ1 public IP address block        
+        default: AZ1 public IP address block
       PublicSubnet2CIDR:
         default: AZ2 public IP address block
       CustomDnsName:
@@ -566,6 +566,7 @@ Resources:
         ClusterNodeMax: !Ref 'ClusterNodeMax'
         ClusterNodeMin: !Ref 'ClusterNodeMin'
         CreateBucket: !Ref 'CreateBucket'
+        CustomDnsName: !Ref 'CustomDnsName'
         DBInstanceClass: !Ref 'DBInstanceClass'
         DBIops: !Ref 'DBIops'
         DBMasterUserPassword: !Ref 'DBMasterUserPassword'

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -338,7 +338,6 @@ Parameters:
     AllowedPattern: '(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*'
     ConstraintDescription: Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
     Description: Password for the Bitbucket user ('atlbitbucket') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
-    MinLength: 8
     MaxLength: 128
     NoEcho: true
     Type: String

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -319,12 +319,12 @@ Parameters:
     MaxValue: 30000
     Type: Number
   DBMasterUserPassword:
-    AllowedPattern: '[a-zA-Z0-9]*'
-    ConstraintDescription: Must be at least 8 alphanumeric characters.
-    Description: Password for the master ('postgres') account.
-    MinLength: 8
+    AllowedPattern: '(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*'
+    ConstraintDescription: Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
+    Description: Password for the master ('postgres') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
+    NoEcho: True
     MaxLength: 128
-    NoEcho: true
+    MinLength: 8
     Type: String
   DBMultiAZ:
     Description: Whether to provision a multi-AZ RDS instance.
@@ -335,9 +335,10 @@ Parameters:
     ConstraintDescription: Must be 'true' or 'false'.
     Type: String
   DBPassword:
-    AllowedPattern: '[a-zA-Z0-9]*'
-    ConstraintDescription: If specified, must be at least 8 alphanumeric characters.
-    Description: Password for the Bitbucket user ('atlbitbucket') account. Max length of 128 characters. Not used if you have specified a Database snapshot ID.
+    AllowedPattern: '(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*'
+    ConstraintDescription: Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
+    Description: Password for the Bitbucket user ('atlbitbucket') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
+    MinLength: 8
     MaxLength: 128
     NoEcho: true
     Type: String
@@ -512,7 +513,7 @@ Conditions:
     !And [Condition: IsVersion5X, !Or [Condition: IsVersionX0, Condition: IsVersionX1, Condition: IsVersionX2, Condition: IsVersionX3, Condition: IsVersionX4, Condition: IsVersionX5, Condition: IsVersionX6]]
   RestoreRDSOrStandby:
     !Or [Condition: RestoreFromRDSSnapshot, Condition: StandbyMode]
-  SetDBMasterUserPassword:
+  SetDBMasterUserAndPassword:
     !And [!Not [!Equals [!Ref DBMasterUserPassword, '']], Condition: NotStandbyMode]
   UsePublicIp:
     !Equals [!Ref InternetFacingLoadBalancer, 'true']
@@ -659,9 +660,9 @@ Resources:
   ClusterNodeGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
-      DesiredCapacity: !If [StandbyMode, 0, !Ref ClusterNodeMin]
+      DesiredCapacity: !If [StandbyMode, '0', !Ref ClusterNodeMin]
       LaunchConfigurationName: !Ref ClusterNodeLaunchConfig
-      MinSize: !If [StandbyMode, 0, !Ref ClusterNodeMin]
+      MinSize: !If [StandbyMode, '0', !Ref ClusterNodeMin]
       MaxSize: !Ref ClusterNodeMax
       LoadBalancerNames: [!Ref LoadBalancer]
       VPCZoneIdentifier: !Select [0, [!Split [ ',', !ImportValue ATL-PriNets]]]
@@ -723,7 +724,7 @@ Resources:
                   - !Sub ["ATL_ELASTICSEARCH_HOST=${ESEndpoint}", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
                   - !Sub ["ATL_ELASTICSEARCH_ENDPOINT=http://${ESEndpoint}", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
                   - !Sub ["ATL_BITBUCKET_PROPERTIES=\"${BitbucketProperties}\"", BitbucketProperties: !Join ["\\\n", !Ref BitbucketProperties]]
-                  - !If [DoSSL, "ATL_SSL_PROXY=true", !Ref "AWS::NoValue"]                  
+                  - !If [DoSSL, "ATL_SSL_PROXY=true", !Ref "AWS::NoValue"]
 
             /opt/atlassian/bin/clone_deployment_repo:
               content: !Sub |
@@ -769,7 +770,6 @@ Resources:
       AssociatePublicIpAddress: false
       BlockDeviceMappings:
         - DeviceName: /dev/sdf
-          Ebs: {}
           NoDevice: true
       KeyName: !If [ KeyProvided, !Ref KeyPairName, !ImportValue ATL-DefaultKey ]
       IamInstanceProfile: !Ref BitbucketClusterNodeInstanceProfile
@@ -796,14 +796,14 @@ Resources:
     Properties:
       AdjustmentType: ChangeInCapacity
       AutoScalingGroupName: !Ref ClusterNodeGroup
-      Cooldown: 600
+      Cooldown: '600'
       ScalingAdjustment: 1
   ClusterNodeScaleDownPolicy:
     Type: AWS::AutoScaling::ScalingPolicy
     Properties:
       AdjustmentType: ChangeInCapacity
       AutoScalingGroupName: !Ref ClusterNodeGroup
-      Cooldown: 600
+      Cooldown: '600'
       ScalingAdjustment: -1
   CPUAlarmHigh:
     Type: AWS::CloudWatch::Alarm
@@ -955,7 +955,7 @@ Resources:
               command: /opt/atlassian/bin/clone_deployment_repo
               ignoreErrors: true
             080_run_atl_init_node:
-              command: !Sub |
+              command:
                 cd /opt/atlassian/dc-deployments-automation/ && ./bin/install-ansible && ./bin/ansible-with-atl-env inv/aws_node_local aws_bitbucket_nfs_node.yml /var/log/ansible-bootstrap.log
               ignoreErrors: true
 
@@ -963,11 +963,11 @@ Resources:
       BlockDeviceMappings:
         - DeviceName: /dev/sdf
           Ebs:
-            VolumeType: !If [IsHomeProvisionedIops, io1, gp2]
-            Iops: !If [IsHomeProvisionedIops, !Ref HomeIops, !Ref "AWS::NoValue"]
             DeleteOnTermination: !Ref HomeDeleteOnTermination
+            Iops: !If [IsHomeProvisionedIops, !Ref HomeIops, !Ref "AWS::NoValue"]
             SnapshotId: !If [RestoreFromEBSSnapshot, !Ref HomeVolumeSnapshotId, !Ref "AWS::NoValue"]
             VolumeSize: !Ref HomeSize
+            VolumeType: !If [IsHomeProvisionedIops, io1, gp2]
         - DeviceName: /dev/sdf
           NoDevice: {}
       IamInstanceProfile: !Ref BitbucketFileServerInstanceProfile
@@ -982,7 +982,7 @@ Resources:
       NetworkInterfaces:
         - GroupSet: [!Ref SecurityGroup]
           AssociatePublicIpAddress: false
-          DeviceIndex: 0
+          DeviceIndex: '0'
           DeleteOnTermination: true
           SubnetId: !Select [0, !Split [ ",", !ImportValue ATL-PriNets] ]
       Tags:
@@ -1012,10 +1012,10 @@ Resources:
       DBSnapshotIdentifier: !If [RestoreFromRDSSnapshot, !Ref DBSnapshotId, !Ref "AWS::NoValue"]
       DBSubnetGroupName: !Ref DBSubnetGroup
       Engine: postgres
-      EngineVersion: 10
+      EngineVersion: '10'
       Iops: !If [DBProvisionedIops, !Ref DBIops, !Ref "AWS::NoValue"]
-      MasterUsername: postgres
-      MasterUserPassword: !If [SetDBMasterUserPassword, !Ref DBMasterUserPassword, !Ref "AWS::NoValue"]
+      MasterUsername: !If ["SetDBMasterUserAndPassword", postgres, !Ref "AWS::NoValue"]
+      MasterUserPassword: !If ["SetDBMasterUserAndPassword", !Ref DBMasterUserPassword, !Ref "AWS::NoValue"]
       MultiAZ: !If [StandbyMode, !Ref "AWS::NoValue", !Ref DBMultiAZ]
       StorageType: !If [DBProvisionedIops, io1, gp2]
       SourceDBInstanceIdentifier: !If [StandbyMode, !Ref DBMaster, !Ref "AWS::NoValue"]
@@ -1041,31 +1041,31 @@ Resources:
         IdleTimeout: 3600
       CrossZone: true
       Listeners:
-        - LoadBalancerPort: 80
+        - LoadBalancerPort: '80'
           Protocol: HTTP
-          InstancePort: !If [DoSSL, 7991, 7990]
+          InstancePort: !If [DoSSL, '7991', '7990']
           InstanceProtocol: HTTP
           PolicyNames: [SessionStickiness]
         - !If
           - DoSSL
-          - LoadBalancerPort: 443
+          - LoadBalancerPort: '443'
             Protocol: HTTPS
-            InstancePort: 7990
+            InstancePort: '7990'
             InstanceProtocol: HTTP
             PolicyNames:
               - SessionStickiness
             SSLCertificateId: !Ref SSLCertificateARN
           - !Ref AWS::NoValue
-        - LoadBalancerPort: 7999
+        - LoadBalancerPort: '7999'
           Protocol: TCP
-          InstancePort: 7999
+          InstancePort: '7999'
           InstanceProtocol: TCP
       HealthCheck:
-        HealthyThreshold: 2
-        Interval: 60
+        HealthyThreshold: '2'
+        Interval: '60'
         Target: HTTP:7990/status
-        Timeout: 29
-        UnhealthyThreshold: 2
+        Timeout: '29'
+        UnhealthyThreshold: '2'
       Scheme: !If [UsePublicIp, 'internet-facing', 'internal']
       SecurityGroups: [!Ref SecurityGroup]
       Subnets: !Split [ ",", !ImportValue ATL-PubNets]
@@ -1104,8 +1104,8 @@ Resources:
     Properties:
       GroupId: !Ref SecurityGroup
       IpProtocol: '-1'
-      FromPort: '-1'
-      ToPort: '-1'
+      FromPort: -1
+      ToPort: -1
       SourceSecurityGroupId: !Ref SecurityGroup
 Outputs:
   ClusterNodeGroup:


### PR DESCRIPTION
This one was slightly trickier.

Linting output before:
```
W2001 Parameter CustomDnsName not used.
templates/quickstart-bitbucket-dc-with-vpc.template.yaml:510:3

E3012 Property Resources/ClusterNodeGroup/Properties/DesiredCapacity/Fn::If/1 should be of type String
templates/quickstart-bitbucket-dc.template.yaml:662:7

E3012 Property Resources/ClusterNodeGroup/Properties/MinSize/Fn::If/1 should be of type String
templates/quickstart-bitbucket-dc.template.yaml:664:7

E2523 Only one of [VirtualName, Ebs, NoDevice] should be specified for Resources/ClusterNodeLaunchConfig/Properties/BlockDeviceMappings/0
templates/quickstart-bitbucket-dc.template.yaml:771:11

E3012 Property Resources/ClusterNodeScaleUpPolicy/Properties/Cooldown should be of type String
templates/quickstart-bitbucket-dc.template.yaml:799:7

E3012 Property Resources/ClusterNodeScaleDownPolicy/Properties/Cooldown should be of type String
templates/quickstart-bitbucket-dc.template.yaml:806:7

W1020 Fn::Sub isn't needed because there are no variables at Resources/FileServer/Metadata/AWS::CloudFormation::Init/config/commands/080_run_atl_init_node/command/Fn::Sub
templates/quickstart-bitbucket-dc.template.yaml:958:15

E2504 Iops shouldn't be defined for type gp2 for Resources/FileServer/Properties/BlockDeviceMappings/0/Ebs/Iops
templates/quickstart-bitbucket-dc.template.yaml:967:13

E3012 Property Resources/FileServer/Properties/NetworkInterfaces/0/DeviceIndex should be of type String
templates/quickstart-bitbucket-dc.template.yaml:985:11

E2521 Property MasterUserPassword should exist with MasterUsername when condition "RestoreFromRDSSnapshot" is False and when condition "DBProvisionedIops" is False and when condition "SetDBMasterUserPassword" is False and when condition "RestoreRDSOrStandby" is False and when condition "StandbyMode" is False for Resources/DB/Properties
templates/quickstart-bitbucket-dc.template.yaml:1007:5

E2521 Property MasterUserPassword should exist with MasterUsername when condition "RestoreFromRDSSnapshot" is False and when condition "DBProvisionedIops" is False and when condition "SetDBMasterUserPassword" is False and when condition "RestoreRDSOrStandby" is True and when condition "StandbyMode" is True for Resources/DB/Properties
templates/quickstart-bitbucket-dc.template.yaml:1007:5

E2521 Property MasterUserPassword should exist with MasterUsername when condition "RestoreFromRDSSnapshot" is False and when condition "DBProvisionedIops" is True and when condition "SetDBMasterUserPassword" is False and when condition "RestoreRDSOrStandby" is False and when condition "StandbyMode" is False for Resources/DB/Properties
templates/quickstart-bitbucket-dc.template.yaml:1007:5

E2521 Property MasterUserPassword should exist with MasterUsername when condition "RestoreFromRDSSnapshot" is False and when condition "DBProvisionedIops" is True and when condition "SetDBMasterUserPassword" is False and when condition "RestoreRDSOrStandby" is True and when condition "StandbyMode" is True for Resources/DB/Properties
templates/quickstart-bitbucket-dc.template.yaml:1007:5

E2521 Property MasterUserPassword should exist with MasterUsername when condition "RestoreFromRDSSnapshot" is True and when condition "DBProvisionedIops" is False and when condition "SetDBMasterUserPassword" is False and when condition "RestoreRDSOrStandby" is True and when condition "StandbyMode" is False for Resources/DB/Properties
templates/quickstart-bitbucket-dc.template.yaml:1007:5

E2521 Property MasterUserPassword should exist with MasterUsername when condition "RestoreFromRDSSnapshot" is True and when condition "DBProvisionedIops" is False and when condition "SetDBMasterUserPassword" is False and when condition "RestoreRDSOrStandby" is True and when condition "StandbyMode" is True for Resources/DB/Properties
templates/quickstart-bitbucket-dc.template.yaml:1007:5

E2521 Property MasterUserPassword should exist with MasterUsername when condition "RestoreFromRDSSnapshot" is True and when condition "DBProvisionedIops" is True and when condition "SetDBMasterUserPassword" is False and when condition "RestoreRDSOrStandby" is True and when condition "StandbyMode" is False for Resources/DB/Properties
templates/quickstart-bitbucket-dc.template.yaml:1007:5

E2521 Property MasterUserPassword should exist with MasterUsername when condition "RestoreFromRDSSnapshot" is True and when condition "DBProvisionedIops" is True and when condition "SetDBMasterUserPassword" is False and when condition "RestoreRDSOrStandby" is True and when condition "StandbyMode" is True for Resources/DB/Properties
templates/quickstart-bitbucket-dc.template.yaml:1007:5

E3012 Property Resources/DB/Properties/EngineVersion should be of type String
templates/quickstart-bitbucket-dc.template.yaml:1015:7

E2520 Property MasterUsername should NOT exist with SourceDBInstanceIdentifier when condition "RestoreFromRDSSnapshot" is False and when condition "DBProvisionedIops" is False and when condition "SetDBMasterUserPassword" is False and when condition "RestoreRDSOrStandby" is True and when condition "StandbyMode" is True for Resources/DB/Properties
templates/quickstart-bitbucket-dc.template.yaml:1021:7

E2520 Property MasterUsername should NOT exist with SourceDBInstanceIdentifier when condition "RestoreFromRDSSnapshot" is False and when condition "DBProvisionedIops" is True and when condition "SetDBMasterUserPassword" is False and when condition "RestoreRDSOrStandby" is True and when condition "StandbyMode" is True for Resources/DB/Properties
templates/quickstart-bitbucket-dc.template.yaml:1021:7

E2520 Property MasterUsername should NOT exist with SourceDBInstanceIdentifier when condition "RestoreFromRDSSnapshot" is True and when condition "DBProvisionedIops" is False and when condition "SetDBMasterUserPassword" is False and when condition "RestoreRDSOrStandby" is True and when condition "StandbyMode" is True for Resources/DB/Properties
templates/quickstart-bitbucket-dc.template.yaml:1021:7

E2520 Property MasterUsername should NOT exist with SourceDBInstanceIdentifier when condition "RestoreFromRDSSnapshot" is True and when condition "DBProvisionedIops" is True and when condition "SetDBMasterUserPassword" is False and when condition "RestoreRDSOrStandby" is True and when condition "StandbyMode" is True for Resources/DB/Properties
templates/quickstart-bitbucket-dc.template.yaml:1021:7

E3012 Property Resources/LoadBalancer/Properties/Listeners/0/LoadBalancerPort should be of type String
templates/quickstart-bitbucket-dc.template.yaml:1044:11

E3012 Property Resources/LoadBalancer/Properties/Listeners/0/InstancePort/Fn::If/1 should be of type String
templates/quickstart-bitbucket-dc.template.yaml:1046:11

E3012 Property Resources/LoadBalancer/Properties/Listeners/0/InstancePort/Fn::If/2 should be of type String
templates/quickstart-bitbucket-dc.template.yaml:1046:11

E3012 Property Resources/LoadBalancer/Properties/Listeners/1/Fn::If/1/LoadBalancerPort should be of type String
templates/quickstart-bitbucket-dc.template.yaml:1051:13

E3012 Property Resources/LoadBalancer/Properties/Listeners/1/Fn::If/1/InstancePort should be of type String
templates/quickstart-bitbucket-dc.template.yaml:1053:13

E3012 Property Resources/LoadBalancer/Properties/Listeners/2/LoadBalancerPort should be of type String
templates/quickstart-bitbucket-dc.template.yaml:1059:11

E3012 Property Resources/LoadBalancer/Properties/Listeners/2/InstancePort should be of type String
templates/quickstart-bitbucket-dc.template.yaml:1061:11

E3012 Property Resources/LoadBalancer/Properties/HealthCheck/HealthyThreshold should be of type String
templates/quickstart-bitbucket-dc.template.yaml:1064:9

E3012 Property Resources/LoadBalancer/Properties/HealthCheck/Interval should be of type String
templates/quickstart-bitbucket-dc.template.yaml:1065:9

E3012 Property Resources/LoadBalancer/Properties/HealthCheck/Timeout should be of type String
templates/quickstart-bitbucket-dc.template.yaml:1067:9

E3012 Property Resources/LoadBalancer/Properties/HealthCheck/UnhealthyThreshold should be of type String
templates/quickstart-bitbucket-dc.template.yaml:1068:9

E3012 Property Resources/SecurityGroupIngress/Properties/FromPort should be of type Integer
templates/quickstart-bitbucket-dc.template.yaml:1107:7

E3012 Property Resources/SecurityGroupIngress/Properties/ToPort should be of type Integer
templates/quickstart-bitbucket-dc.template.yaml:1108:7
```

Build
https://server-syd-bamboo.internal.atlassian.com/browse/ZDCD-AWSBITBUCKET4-LINT-3