### PR TITLE
DCD-578: Clean-up volume creation

### DIFF
--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -15,7 +15,7 @@ Metadata:
           - AccessCIDR
           - VPCCIDR
           - AvailabilityZones
-          - AssociatePublicIpAddress
+          - InternetFacingLoadBalancer
           - CustomDnsName
           - SSLCertificateARN
           - PrivateSubnet1CIDR
@@ -66,8 +66,6 @@ Metadata:
         default: Trusted IP range
       AvailabilityZones:
         default: Availability Zones
-      AssociatePublicIpAddress:
-        default: Assign public IP
       BitbucketProperties:
         default: Bitbucket properties
       BitbucketVersion:
@@ -128,6 +126,8 @@ Metadata:
         default: Home directory size
       HomeVolumeSnapshotId:
         default: Home volume snapshot ID to restore
+      InternetFacingLoadBalancer:
+        default: Make instance internet facing
       KeyPairName:
         default: Key Name
       PrivateSubnet1CIDR:
@@ -201,12 +201,6 @@ Parameters:
     Default: 10.0.0.0/16
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
     Description: CIDR Block for the VPC
-    Type: String
-  AssociatePublicIpAddress:
-    Default: true
-    AllowedValues: [true, false]
-    ConstraintDescription: Must be 'true' or 'false'.
-    Description: Controls if the EC2 instances are assigned a public IP address
     Type: String
   BitbucketProperties:
     Default: ''
@@ -507,6 +501,12 @@ Parameters:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
     Description: The EC2 Key Pair to allow SSH access to the instances
     Type: AWS::EC2::KeyPair::KeyName
+  InternetFacingLoadBalancer:
+    Default: true
+    AllowedValues: [true, false]
+    ConstraintDescription: Must be 'true' or 'false'.
+    Description: Controls whether the load balancer should be visible to the internet (true) or only within the VPC (false).
+    Type: String
   CustomDnsName:
     Default: ""
     Description: 'Use custom existing DNS name for your Data Center instance. Please note: you must own the domain and configure it to point at the load balancer.'
@@ -554,7 +554,7 @@ Resources:
             - s3-us-gov-west-1
             - s3
       Parameters:
-        AssociatePublicIpAddress: !Ref 'AssociatePublicIpAddress'
+        InternetFacingLoadBalancer: !Ref 'InternetFacingLoadBalancer'
         BitbucketProperties: !Join
           - ','
           - !Ref 'BitbucketProperties'

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -38,8 +38,8 @@ Metadata:
       - Label:
           default: Networking
         Parameters:
-          - AssociatePublicIpAddress
           - CidrBlock
+          - InternetFacingLoadBalancer
           - KeyPairName
           - CustomDnsName
           - SSLCertificateARN
@@ -62,8 +62,6 @@ Metadata:
           - DeploymentAutomationKeyName
 
     ParameterLabels:
-      AssociatePublicIpAddress:
-        default: Assign public IP
       BitbucketProperties:
         default: Bitbucket properties
       BitbucketVersion:
@@ -126,6 +124,8 @@ Metadata:
         default: Home volume snapshot ID to restore
       HomeVolumeType:
         default: Home directory volume type
+      InternetFacingLoadBalancer:
+        default: Make instance internet facing
       KeyPairName:
         default: Key Name *
       CustomDnsName:
@@ -134,12 +134,6 @@ Metadata:
         default: SSL Certificate ARN
 
 Parameters:
-  AssociatePublicIpAddress:
-    Default: true
-    AllowedValues: [true, false]
-    ConstraintDescription: Must be 'true' or 'false'.
-    Description: Controls if the EC2 instances are assigned a public IP address
-    Type: String
   BitbucketProperties:
     Default: ''
     Description: A comma-separated list of bitbucket properties in the form 'key1=value1, key2=value2, ...' Find documentation at https://confluence.atlassian.com/x/m5ZKLg
@@ -446,6 +440,12 @@ Parameters:
     AllowedValues: [General Purpose (SSD), Provisioned IOPS]
     ConstraintDescription: Must be 'General Purpose (SSD)' or 'Provisioned IOPS'.
     Type: String
+  InternetFacingLoadBalancer:
+    Default: true
+    AllowedValues: [true, false]
+    ConstraintDescription: Must be 'true' or 'false'.
+    Description: Controls whether the load balancer should be visible to the internet (true) or only within the VPC (false).
+    Type: String
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
     Description: The EC2 Key Pair to allow SSH access to the instances
@@ -515,7 +515,7 @@ Conditions:
   SetDBMasterUserPassword:
     !And [!Not [!Equals [!Ref DBMasterUserPassword, '']], Condition: NotStandbyMode]
   UsePublicIp:
-    !Equals [!Ref AssociatePublicIpAddress, 'true']
+    !Equals [!Ref InternetFacingLoadBalancer, 'true']
 
 Mappings:
   AWSRegionArch2AMI:

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -767,10 +767,6 @@ Resources:
 
     Properties:
       AssociatePublicIpAddress: false
-      BlockDeviceMappings:
-        - DeviceName: /dev/sdf
-          Ebs: {}
-          NoDevice: true
       KeyName: !If [ KeyProvided, !Ref KeyPairName, !ImportValue ATL-DefaultKey ]
       IamInstanceProfile: !Ref BitbucketClusterNodeInstanceProfile
       ImageId:
@@ -881,7 +877,7 @@ Resources:
                   - ATL_ENABLED_PRODUCTS=
                   - ATL_ENABLED_SHARED_HOMES=Bitbucket
                   - ATL_APP_NFS_SERVER=true
-                  - ATL_NFS_SERVER_DEVICE=/dev/sdf
+                  - ATL_NFS_SERVER_DEVICE=/dev/xvdf
                   # NOTE: For simplicity we should keep this as close to the BB node version above.
                   - !Sub ["ATL_PRODUCT_VERSION=${BitbucketVersion}", BitbucketVersion: !Ref BitbucketVersion]
                   - !Sub ["ATL_PROXY_NAME=${LoadBalancerDNSName}", LoadBalancerDNSName: !GetAtt LoadBalancer.DNSName]
@@ -961,15 +957,13 @@ Resources:
 
     Properties:
       BlockDeviceMappings:
-        - DeviceName: /dev/sdf
+        - DeviceName: /dev/xvdf
           Ebs:
             VolumeType: !If [IsHomeProvisionedIops, io1, gp2]
             Iops: !If [IsHomeProvisionedIops, !Ref HomeIops, !Ref "AWS::NoValue"]
             DeleteOnTermination: !Ref HomeDeleteOnTermination
             SnapshotId: !If [RestoreFromEBSSnapshot, !Ref HomeVolumeSnapshotId, !Ref "AWS::NoValue"]
             VolumeSize: !Ref HomeSize
-        - DeviceName: /dev/sdf
-          NoDevice: {}
       IamInstanceProfile: !Ref BitbucketFileServerInstanceProfile
       EbsOptimized: true
       ImageId:


### PR DESCRIPTION
Remove some cruft from the EC2 volume settings, and rename the NFS volume from /dev/sdf to /dev/xvdf for consistency.
