### PR TITLE
DCD-595: Add default taskcat build and fix EBS VolumeType & password quoting

### DIFF
--- a/ci/params/default/quickstart-bitbucket-default.json
+++ b/ci/params/default/quickstart-bitbucket-default.json
@@ -5,7 +5,7 @@
     },
     {
         "ParameterKey": "DBMasterUserPassword",
-        "ParameterValue": "$[taskcat_genpass_8S]"
+        "ParameterValue": "$[taskcat_genpass_8A]#"
     },
     {
         "ParameterKey": "CidrBlock",
@@ -21,7 +21,7 @@
     },
     {
         "ParameterKey": "DBPassword",
-        "ParameterValue": "$[taskcat_genpass_8S]"
+        "ParameterValue": "$[taskcat_genpass_8A]#"
     },
     {
         "ParameterKey": "KeyPairName",

--- a/ci/params/default/quickstart-bitbucket-default.json
+++ b/ci/params/default/quickstart-bitbucket-default.json
@@ -9,7 +9,7 @@
   },
   {
     "ParameterKey": "DBMasterUserPassword",
-    "ParameterValue": "DcD81_21ax"
+    "ParameterValue": "f925dO1ry_"
   },
   {
     "ParameterKey": "CidrBlock",
@@ -25,7 +25,7 @@
   },
   {
     "ParameterKey": "DBPassword",
-    "ParameterValue": "dCd23_2abca"
+    "ParameterValue": "f925dO1ry_"
   },
   {
     "ParameterKey": "KeyPairName",

--- a/ci/params/default/quickstart-bitbucket-default.json
+++ b/ci/params/default/quickstart-bitbucket-default.json
@@ -9,7 +9,7 @@
   },
   {
     "ParameterKey": "DBMasterUserPassword",
-    "ParameterValue": "$[taskcat_genpass_8S]"
+    "ParameterValue": "DcD81_21ax"
   },
   {
     "ParameterKey": "CidrBlock",
@@ -25,7 +25,7 @@
   },
   {
     "ParameterKey": "DBPassword",
-    "ParameterValue": "$[taskcat_genpass_8S]"
+    "ParameterValue": "dCd23_2abca"
   },
   {
     "ParameterKey": "KeyPairName",

--- a/ci/params/default/quickstart-bitbucket-default.json
+++ b/ci/params/default/quickstart-bitbucket-default.json
@@ -1,0 +1,30 @@
+[
+    {
+        "ParameterKey": "BitbucketVersion",
+        "ParameterValue": "6.6.0"
+    },
+    {
+        "ParameterKey": "DBMasterUserPassword",
+        "ParameterValue": "$[taskcat_genpass_8S]"
+    },
+    {
+        "ParameterKey": "CidrBlock",
+        "ParameterValue": "10.0.0.0/0"
+    },
+    {
+        "ParameterKey": "DBInstanceClass",
+        "ParameterValue": "db.t2.large"
+    },
+    {
+        "ParameterKey": "DBIops",
+        "ParameterValue": "1000"
+    },
+    {
+        "ParameterKey": "DBPassword",
+        "ParameterValue": "$[taskcat_genpass_8S]"
+    },
+    {
+        "ParameterKey": "KeyPairName",
+        "ParameterValue": "replaced-by-taskcat-override-file"
+    }
+]

--- a/ci/params/default/quickstart-bitbucket-default.json
+++ b/ci/params/default/quickstart-bitbucket-default.json
@@ -25,7 +25,7 @@
   },
   {
     "ParameterKey": "DBPassword",
-    "ParameterValue": "$[taskcat_genpass_8S]#"
+    "ParameterValue": "$[taskcat_genpass_8S]"
   },
   {
     "ParameterKey": "KeyPairName",

--- a/ci/params/default/quickstart-bitbucket-default.json
+++ b/ci/params/default/quickstart-bitbucket-default.json
@@ -9,7 +9,7 @@
     },
     {
         "ParameterKey": "CidrBlock",
-        "ParameterValue": "10.0.0.0/0"
+        "ParameterValue": "0.0.0.0/0"
     },
     {
         "ParameterKey": "DBInstanceClass",

--- a/ci/params/default/quickstart-bitbucket-default.json
+++ b/ci/params/default/quickstart-bitbucket-default.json
@@ -1,30 +1,34 @@
 [
-    {
-        "ParameterKey": "BitbucketVersion",
-        "ParameterValue": "6.6.0"
-    },
-    {
-        "ParameterKey": "DBMasterUserPassword",
-        "ParameterValue": "$[taskcat_genpass_8A]#"
-    },
-    {
-        "ParameterKey": "CidrBlock",
-        "ParameterValue": "0.0.0.0/0"
-    },
-    {
-        "ParameterKey": "DBInstanceClass",
-        "ParameterValue": "db.t2.large"
-    },
-    {
-        "ParameterKey": "DBIops",
-        "ParameterValue": "1000"
-    },
-    {
-        "ParameterKey": "DBPassword",
-        "ParameterValue": "$[taskcat_genpass_8A]#"
-    },
-    {
-        "ParameterKey": "KeyPairName",
-        "ParameterValue": "replaced-by-taskcat-override-file"
-    }
+  {
+    "ParameterKey": "DBMultiAZ",
+    "ParameterValue": "false"
+  },
+  {
+    "ParameterKey": "BitbucketVersion",
+    "ParameterValue": "6.6.0"
+  },
+  {
+    "ParameterKey": "DBMasterUserPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
+    "ParameterKey": "CidrBlock",
+    "ParameterValue": "0.0.0.0/0"
+  },
+  {
+    "ParameterKey": "DBInstanceClass",
+    "ParameterValue": "db.t2.large"
+  },
+  {
+    "ParameterKey": "DBIops",
+    "ParameterValue": "1000"
+  },
+  {
+    "ParameterKey": "DBPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]#"
+  },
+  {
+    "ParameterKey": "KeyPairName",
+    "ParameterValue": "replaced-by-taskcat-override-file"
+  }
 ]

--- a/ci/params/default/taskcat.yml
+++ b/ci/params/default/taskcat.yml
@@ -1,0 +1,26 @@
+---
+global:
+  qsname: quickstart-atlassian-bitbucket
+  owner: quickstart-eng@amazon.com
+  marketplace-ami: false
+  reporting: true
+  regions:
+    - ap-northeast-1
+    - ap-northeast-2
+    - ap-south-1
+    - ap-southeast-1
+    - ap-southeast-2
+    - eu-central-1
+    - eu-west-1
+    - sa-east-1
+    - us-east-1
+    - us-east-2
+    - us-west-1
+    - us-west-2
+
+tests:
+  BB-5:
+    template_file: quickstart-bitbucket-dc.template.yaml
+    parameter_input: params/default/quickstart-bitbucket-default.json
+    regions:
+     - us-east-1

--- a/ci/quickstart-bitbucket-master-v5.json
+++ b/ci/quickstart-bitbucket-master-v5.json
@@ -9,7 +9,7 @@
     },
     {
         "ParameterKey": "DBMasterUserPassword",
-        "ParameterValue": "$[taskcat_genpass_8]"
+        "ParameterValue": "$[taskcat_genpass_8S]"
     },
     {
         "ParameterKey": "AccessCIDR",
@@ -25,7 +25,7 @@
     },
     {
         "ParameterKey": "DBPassword",
-        "ParameterValue": "$[taskcat_genpass_8]"
+        "ParameterValue": "$[taskcat_genpass_8S]"
     },
     {
         "ParameterKey": "KeyPairName",

--- a/ci/quickstart-bitbucket-master-v5.json
+++ b/ci/quickstart-bitbucket-master-v5.json
@@ -9,7 +9,7 @@
     },
     {
         "ParameterKey": "DBMasterUserPassword",
-        "ParameterValue": "DcD3156_a_x"
+        "ParameterValue": "f925dO1ry_"
     },
     {
         "ParameterKey": "AccessCIDR",
@@ -25,7 +25,7 @@
     },
     {
         "ParameterKey": "DBPassword",
-        "ParameterValue": "zafeg156_a_x"
+        "ParameterValue": "f925dO1ry_"
     },
     {
         "ParameterKey": "KeyPairName",

--- a/ci/quickstart-bitbucket-master-v5.json
+++ b/ci/quickstart-bitbucket-master-v5.json
@@ -9,7 +9,7 @@
     },
     {
         "ParameterKey": "DBMasterUserPassword",
-        "ParameterValue": "$[taskcat_genpass_8S]#"
+        "ParameterValue": "$[taskcat_genpass_8S]"
     },
     {
         "ParameterKey": "AccessCIDR",
@@ -25,7 +25,7 @@
     },
     {
         "ParameterKey": "DBPassword",
-        "ParameterValue": "$[taskcat_genpass_8S]#"
+        "ParameterValue": "$[taskcat_genpass_8S]"
     },
     {
         "ParameterKey": "KeyPairName",

--- a/ci/quickstart-bitbucket-master-v5.json
+++ b/ci/quickstart-bitbucket-master-v5.json
@@ -9,7 +9,7 @@
     },
     {
         "ParameterKey": "DBMasterUserPassword",
-        "ParameterValue": "$[taskcat_genpass_8A]#"
+        "ParameterValue": "$[taskcat_genpass_8S]#"
     },
     {
         "ParameterKey": "AccessCIDR",
@@ -25,7 +25,7 @@
     },
     {
         "ParameterKey": "DBPassword",
-        "ParameterValue": "$[taskcat_genpass_8A]#"
+        "ParameterValue": "$[taskcat_genpass_8S]#"
     },
     {
         "ParameterKey": "KeyPairName",

--- a/ci/quickstart-bitbucket-master-v5.json
+++ b/ci/quickstart-bitbucket-master-v5.json
@@ -5,11 +5,11 @@
     },
     {
         "ParameterKey": "BitbucketVersion",
-        "ParameterValue": "5.16.0"
+        "ParameterValue": "6.6.0"
     },
     {
         "ParameterKey": "DBMasterUserPassword",
-        "ParameterValue": "$[taskcat_genpass_8S]"
+        "ParameterValue": "$[taskcat_genpass_8A]#"
     },
     {
         "ParameterKey": "AccessCIDR",
@@ -25,7 +25,7 @@
     },
     {
         "ParameterKey": "DBPassword",
-        "ParameterValue": "$[taskcat_genpass_8S]"
+        "ParameterValue": "$[taskcat_genpass_8A]#"
     },
     {
         "ParameterKey": "KeyPairName",

--- a/ci/quickstart-bitbucket-master-v5.json
+++ b/ci/quickstart-bitbucket-master-v5.json
@@ -9,7 +9,7 @@
     },
     {
         "ParameterKey": "DBMasterUserPassword",
-        "ParameterValue": "$[taskcat_genpass_8S]"
+        "ParameterValue": "DcD3156_a_x"
     },
     {
         "ParameterKey": "AccessCIDR",
@@ -25,7 +25,7 @@
     },
     {
         "ParameterKey": "DBPassword",
-        "ParameterValue": "$[taskcat_genpass_8S]"
+        "ParameterValue": "zafeg156_a_x"
     },
     {
         "ParameterKey": "KeyPairName",

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -963,6 +963,7 @@ Resources:
             Iops: !If [IsHomeProvisionedIops, !Ref HomeIops, !Ref "AWS::NoValue"]
             SnapshotId: !If [RestoreFromEBSSnapshot, !Ref HomeVolumeSnapshotId, !Ref "AWS::NoValue"]
             VolumeSize: !Ref HomeSize
+            VolumeType: !If [IsHomeProvisionedIops, io1, gp2]
       IamInstanceProfile: !Ref BitbucketFileServerInstanceProfile
       EbsOptimized: true
       ImageId:

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -705,8 +705,8 @@ Resources:
                   - "ATL_JDBC_DB_NAME=bitbucket"
                   - "ATL_JDBC_DRIVER=org.postgresql.Driver"
                   - "ATL_JDBC_USER=atlbitbucket"
-                  - !Sub ["ATL_JDBC_PASSWORD=${DBPassword}", DBPassword: !Ref DBPassword]
-                  - !Sub ["ATL_DB_ROOT_PASSWORD=${DBMasterUserPassword}", DBMasterUserPassword: !Ref DBMasterUserPassword]
+                  - !Sub ["ATL_JDBC_PASSWORD='${DBPassword}'", DBPassword: !Ref DBPassword]
+                  - !Sub ["ATL_DB_ROOT_PASSWORD='${DBMasterUserPassword}'", DBMasterUserPassword: !Ref DBMasterUserPassword]
                   - !Sub ["ATL_DB_HOST=${DBEndpointAddress}", DBEndpointAddress: !GetAtt DB.Endpoint.Address]
                   - !Sub ["ATL_DB_PORT=${DBEndpointPort}", DBEndpointPort: !GetAtt DB.Endpoint.Port]
                   - !Sub ["ATL_JDBC_URL=jdbc:postgresql://${DBEndpointAddress}:${DBEndpointPort}/confluence", { DBEndpointAddress: !GetAtt DB.Endpoint.Address, DBEndpointPort: !GetAtt DB.Endpoint.Port }]
@@ -890,8 +890,8 @@ Resources:
                   - "ATL_JDBC_DB_NAME=bitbucket"
                   - "ATL_JDBC_DRIVER=org.postgresql.Driver"
                   - "ATL_JDBC_USER=atlbitbucket"
-                  - !Sub ["ATL_JDBC_PASSWORD=${DBPassword}", DBPassword: !Ref DBPassword]
-                  - !Sub ["ATL_DB_ROOT_PASSWORD=${DBMasterUserPassword}", DBMasterUserPassword: !Ref DBMasterUserPassword]
+                  - !Sub ["ATL_JDBC_PASSWORD='${DBPassword}'", DBPassword: !Ref DBPassword]
+                  - !Sub ["ATL_DB_ROOT_PASSWORD='${DBMasterUserPassword}'", DBMasterUserPassword: !Ref DBMasterUserPassword]
                   - !Sub ["ATL_DB_HOST=${DBEndpointAddress}", DBEndpointAddress: !GetAtt DB.Endpoint.Address]
                   - !Sub ["ATL_DB_PORT=${DBEndpointPort}", DBEndpointPort: !GetAtt DB.Endpoint.Port]
                   - !Sub ["ATL_JDBC_URL=jdbc:postgresql://${DBEndpointAddress}:${DBEndpointPort}/confluence", { DBEndpointAddress: !GetAtt DB.Endpoint.Address, DBEndpointPort: !GetAtt DB.Endpoint.Port }]


### PR DESCRIPTION
* Added default `taskcat` param file
* Quoted JDBC and Postgres passwords in `/etc/atl` - DCD-547
* Workaround for autogenerated `taskcat` passwords containing forbidden characters