### PR TITLE
DCD-659: Reduce instance class for db and app node for builds

### DIFF
--- a/ci/params/default/quickstart-bitbucket-default.json
+++ b/ci/params/default/quickstart-bitbucket-default.json
@@ -30,5 +30,13 @@
   {
     "ParameterKey": "KeyPairName",
     "ParameterValue": "replaced-by-taskcat-override-file"
-  }
+  },
+  {
+    "ParameterKey": "ClusterNodeInstanceType",
+    "ParameterValue": "t3.medium"
+},
+{
+    "ParameterKey": "DBInstanceClass",
+    "ParameterValue": "db.t3.medium"
+}
 ]


### PR DESCRIPTION
I've reduced the instance class for our builds so we can save some  💵 I've intentionally excluded the taskcat config that isn't under the `params` directory because that is for the AWS builds and I didn't want to change their config.