### PR TITLE
Pass Cloudwatch integration param down to child template

### DIFF
--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -580,6 +580,7 @@ Resources:
         JvmHeapOverride: !Ref 'JvmHeapOverride'
         JvmSupportOpts: !Ref 'JvmSupportOpts'
         CidrBlock: !Ref 'AccessCIDR'
+        CloudWatchIntegration: !Ref 'CloudWatchIntegration'
         ClusterNodeInstanceType: !Ref 'ClusterNodeInstanceType'
         ClusterNodeMax: !Ref 'ClusterNodeMax'
         ClusterNodeMin: !Ref 'ClusterNodeMin'


### PR DESCRIPTION
In the bitbucket-with-vpc template we had the CloudwatchIntegration param but didn't actually pass it down.