### PR TITLE
Add Aurora support 

### DIFF
--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -351,6 +351,12 @@ Parameters:
       - db.r4.4xlarge
       - db.r4.8xlarge
       - db.r4.16xlarge
+      - db.r5.large
+      - db.r5.xlarge
+      - db.r5.2xlarge
+      - db.r5.4xlarge
+      - db.r5.12xlarge
+      - db.r5.24xlarge
       - db.t2.medium
       - db.t2.large
       - db.t2.xlarge
@@ -360,7 +366,7 @@ Parameters:
       - db.t3.xlarge
       - db.t3.2xlarge
     ConstraintDescription: Must be a valid RDS instance class from the list
-    Description: RDS instance type (must be r4 family if using Aurora).
+    Description: RDS instance type (only r4 and r5 families are supported for Aurora).
     Type: String
   DBIops:
     Default: 1000
@@ -562,10 +568,7 @@ Parameters:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
     Description: CIDR Block for the VPC
     Type: String
-    MinValue: 100
-    MaxValue: 16384
-    Type: Number
-
+    
 Conditions:
   GovCloudCondition: !Equals
     - !Ref 'AWS::Region'

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -3,33 +3,18 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: "Atlassian Bitbucket Data Center in new VPC License: Apache 2.0"
 Metadata:
   AWS::CloudFormation::Interface:
-
     ParameterGroups:
       - Label:
           default: Bitbucket setup
         Parameters:
           - BitbucketVersion
       - Label:
-          default: Networking
-        Parameters:
-          - KeyPairName
-          - AccessCIDR
-          - VPCCIDR
-          - AvailabilityZones
-          - InternetFacingLoadBalancer
-          - CustomDnsName
-          - SSLCertificateARN
-          - PrivateSubnet1CIDR
-          - PrivateSubnet2CIDR
-          - PublicSubnet1CIDR
-          - PublicSubnet2CIDR
-      - Label:
           default: Cluster nodes
         Parameters:
           - CloudWatchIntegration
           - ClusterNodeInstanceType
-          - ClusterNodeMin
           - ClusterNodeMax
+          - ClusterNodeMin
       - Label:
           default: File server
         Parameters:
@@ -42,29 +27,43 @@ Metadata:
         Parameters:
           - DBEngine
           - DBInstanceClass
+          - DBIops
           - DBMasterUserPassword
+          - DBMultiAZ
           - DBPassword
           - DBStorage
           - DBStorageType
-          - DBIops
-          - DBMultiAZ
       - Label:
           default: Elasticsearch
         Parameters:
           - ElasticsearchInstanceType
       - Label:
+          default: Networking
+        Parameters:
+          - AccessCIDR
+          - InternetFacingLoadBalancer
+          - KeyPairName
+          - CustomDnsName
+          - SSLCertificateARN
+          - VPCCIDR
+          - AvailabilityZones
+          - PrivateSubnet1CIDR
+          - PrivateSubnet2CIDR
+          - PublicSubnet1CIDR
+          - PublicSubnet2CIDR
+      - Label:
           default: Advanced (Optional)
         Parameters:
-          - DBSnapshotId
-          - HomeVolumeSnapshotId
-          - CreateBucket
-          - ESBucketName
-          - ESSnapshotId
           - BitbucketProperties
           - JvmHeapOverride
           - JvmSupportOpts
-          - HomeDeleteOnTermination
+          - CreateBucket
           - DBMaster
+          - DBSnapshotId
+          - ESBucketName
+          - ESSnapshotId
+          - HomeVolumeSnapshotId
+          - HomeDeleteOnTermination
           - DeploymentAutomationRepository
           - DeploymentAutomationBranch
           - DeploymentAutomationPlaybook
@@ -74,18 +73,16 @@ Metadata:
           - QSS3KeyPrefix
 
     ParameterLabels:
-      AccessCIDR:
-        default: Trusted IP range
-      AvailabilityZones:
-        default: Availability Zones
       BitbucketProperties:
         default: Bitbucket properties
       BitbucketVersion:
-        default: Version
+        default: Version *
       JvmHeapOverride:
         default: JVM Heap Size Override
       JvmSupportOpts:
         default: Additional JVM options
+      AccessCIDR:
+        default: Permitted IP range *
       ClusterNodeMax:
         default: Maximum number of cluster nodes
       ClusterNodeMin:
@@ -94,6 +91,26 @@ Metadata:
         default: Bitbucket cluster node instance type
       CreateBucket:
         default: Create S3 bucket for Elasticsearch snapshots
+      DBEngine:
+        default: The database engine to deploy with (PostgreSQL or Amazon Aurora PostgreSQL)
+      DBInstanceClass:
+        default: Database instance class
+      DBIops:
+        default: RDS Provisioned IOPS
+      DBMasterUserPassword:
+        default: Master password *
+      DBMaster:
+        default: Bitbucket primary database
+      DBMultiAZ:
+        default: Enable RDS Multi-AZ deployment
+      DBPassword:
+        default: Bitbucket database password *
+      DBStorage:
+        default: Database storage
+      DBStorageType:
+        default: Database storage type
+      DBSnapshotId:
+        default: Database snapshot ID to restore
       DeploymentAutomationRepository:
         default: Deployment Automation Git Repository URL
       DeploymentAutomationBranch:
@@ -106,56 +123,28 @@ Metadata:
         default: SSH key name to use with the repository
       CloudWatchIntegration:
         default: Enable CloudWatch integration
+      ElasticsearchInstanceType:
+        default: Elasticsearch instance type
       ESBucketName:
         default: Elasticsearch snapshot S3 bucket name
       ESSnapshotId:
         default: Elasticsearch snapshot ID to restore
-      DBEngine:
-        default: The database engine to deploy with (PostgreSQL or Amazon Aurora PostgreSQL)
-      DBInstanceClass:
-        default: RDS instance class
-      DBMasterUserPassword:
-        default: Master password
-      DBPassword:
-        default: Bitbucket database password
-      DBMaster:
-        default: Bitbucket primary database
-      DBStorage:
-        default: Database storage
-      DBMultiAZ:
-        default: Enable RDS Multi-AZ deployment
-      DBStorageType:
-        default: Database storage type
-      DBIops:
-        default: RDS Provisioned IOPS
-      DBSnapshotId:
-        default: Database snapshot ID to restore
-      ElasticsearchInstanceType:
-        default: Elasticsearch instance type
       FileServerInstanceType:
         default: File server instance type
       HomeDeleteOnTermination:
         default: Delete Home on termination
       HomeIops:
         default: Home directory IOPS
-      HomeVolumeType:
-        default: Home directory volume type
       HomeSize:
         default: Home directory size
       HomeVolumeSnapshotId:
         default: Home volume snapshot ID to restore
+      HomeVolumeType:
+        default: Home directory volume type
       InternetFacingLoadBalancer:
         default: Make instance internet facing
       KeyPairName:
         default: SSH Key Pair Name
-      PrivateSubnet1CIDR:
-        default: AZ1 private IP address block
-      PrivateSubnet2CIDR:
-        default: AZ2 private IP address block
-      PublicSubnet1CIDR:
-        default: AZ1 public IP address block
-      PublicSubnet2CIDR:
-        default: AZ2 public IP address block
       CustomDnsName:
         default: Existing DNS name
       SSLCertificateARN:
@@ -164,62 +153,20 @@ Metadata:
         default: Quick Start S3 Bucket Name
       QSS3KeyPrefix:
         default: Quick Start S3 Key Prefix
+      AvailabilityZones:
+        default: Availability Zones
       VPCCIDR:
         default: IP address block for the VPC
+      PrivateSubnet1CIDR:
+        default: AZ1 private IP address block
+      PrivateSubnet2CIDR:
+        default: AZ2 private IP address block
+      PublicSubnet1CIDR:
+        default: AZ1 public IP address block
+      PublicSubnet2CIDR:
+        default: AZ2 public IP address block
 
 Parameters:
-  AccessCIDR:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
-    Description: CIDR block allowed to access the Atlassian product. This should be set to a trusted IP range; if you want to give public access use '0.0.0.0/0'.
-    Type: String
-  AvailabilityZones:
-    Description: 'List of Availability Zones to use for the subnets in the VPC. Note:
-      The logical order is preserved and only 2 AZs are used for this deployment.'
-    Type: List<AWS::EC2::AvailabilityZone::Name>
-  PrivateSubnet1CIDR:
-    Default: 10.0.0.0/19
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
-    Description: CIDR block for private subnet 1 located in Availability Zone 1.
-    Type: String
-  PrivateSubnet2CIDR:
-    Default: 10.0.32.0/19
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
-    Description: CIDR block for private subnet 2 located in Availability Zone 2.
-    Type: String
-  PublicSubnet1CIDR:
-    Default: 10.0.128.0/20
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
-    Description: CIDR Block for the public DMZ subnet 1 located in Availability Zone 1
-    Type: String
-  PublicSubnet2CIDR:
-    Default: 10.0.144.0/20
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
-    Description: CIDR Block for the public DMZ subnet 2 located in Availability Zone 2
-    Type: String
-  QSS3BucketName:
-    Default: 'aws-quickstart'
-    AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
-    ConstraintDescription: Quick Start bucket name can include numbers, lowercase
-      letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen
-      (-).
-    Description: S3 bucket name for the Quick Start assets. Quick Start bucket name
-      can include numbers, lowercase letters, uppercase letters, and hyphens (-).
-      It cannot start or end with a hyphen (-).
-    Type: String
-  QSS3KeyPrefix:
-    Default: 'quickstart-atlassian-bitbucket/'
-    AllowedPattern: ^[0-9a-zA-Z-/]*$
-    ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters,
-      uppercase letters, hyphens (-), and forward slash (/).
-    Description: S3 key prefix for the Quick Start assets. Quick Start key prefix
-      can include numbers, lowercase letters, uppercase letters, hyphens (-), and
-      forward slash (/).
-    Type: String
-  VPCCIDR:
-    Default: 10.0.0.0/16
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
-    Description: CIDR Block for the VPC
-    Type: String
   BitbucketProperties:
     Default: ''
     Description: A comma-separated list of bitbucket properties in the form 'key1=value1, key2=value2, ...' Find documentation at https://confluence.atlassian.com/x/m5ZKLg
@@ -237,6 +184,13 @@ Parameters:
   JvmSupportOpts:
     Default: ''
     Description: Pass in any additional JVM options to tune the Bitbucket instance
+    Type: String
+  AccessCIDR:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    ConstraintDescription: Must be a valid IP CIDR range of the form x.x.x.x/x.
+    Description: CIDR block allowed to access the Atlassian product. This should be set to a trusted IP range; if you want to give public access use '0.0.0.0/0'.
+    MinLength: 9
+    MaxLength: 18
     Type: String
   ClusterNodeInstanceType:
     Default: c5.xlarge
@@ -334,13 +288,13 @@ Parameters:
     ConstraintDescription: Must be an EC2 instance type from the selection list
     Description: 'Instance type for the cluster application nodes. See https://confluence.atlassian.com/x/GpdKLg for guidance'
     Type: String
-  ClusterNodeMin:
-    Default: 1
-    Description: Set to 1 for new deployment. Can be updated post launch.
-    Type: Number
   ClusterNodeMax:
     Description: Maximum number of nodes in the cluster.
     Default: 2
+    Type: Number
+  ClusterNodeMin:
+    Default: 1
+    Description: Set to 1 for new deployment. Can be updated post launch.
     Type: Number
   CreateBucket:
     Default: true
@@ -374,18 +328,6 @@ Parameters:
     Description: "Enables CloudWatch metrics with or without log gathering. If cost is an issue, you can disable this altogether."
     AllowedValues: ["Off", "Metrics Only", "Metrics and Logs"]
     ConstraintDescription: "Must be 'Off', 'Metrics Only', or 'Metrics and Logs'"
-  ESBucketName:
-    Default: ''
-    AllowedPattern: '[a-z0-9-]*'
-    ConstraintDescription: Must contain only lowercase letters, numbers and hyphens (-).
-    Description: Name of a new, or existing, S3 bucket configured for Elasticsearch snapshots.
-    Type: String
-  ESSnapshotId:
-    Default: ''
-    AllowedPattern: '[a-z0-9-]*'
-    ConstraintDescription: Must contain only lowercase letters, numbers and hyphens (-).
-    Description: Must be a valid snapshot ID for a snapshot in the configured S3 snapshot repository, must be used in conjunction with ESBucketName set to a correctly configured bucket.
-    Type: String
   DBEngine:
     Default: 'PostgreSQL'
     Description: 'Database Engine to use. PostgreSQL or Amazon Aurora Clustered PostgreSQL'
@@ -416,7 +358,7 @@ Parameters:
       - db.t3.medium
       - db.t3.large
       - db.t3.xlarge
-      - db.t3.2xlarge      
+      - db.t3.2xlarge
     ConstraintDescription: Must be a valid RDS instance class from the list
     Description: RDS instance type (must be r4 family if using Aurora).
     Type: String
@@ -492,6 +434,18 @@ Parameters:
       - i2.xlarge.elasticsearch
       - i2.2xlarge.elasticsearch
     ConstraintDescription: Must be an Elasticsearch instance type in the M4, R4 or I2 family
+  ESBucketName:
+    Default: ''
+    AllowedPattern: '[a-z0-9-]*'
+    ConstraintDescription: Must contain only lowercase letters, numbers and hyphens (-).
+    Description: Name of a new, or existing, S3 bucket configured for Elasticsearch snapshots.
+    Type: String
+  ESSnapshotId:
+    Default: ''
+    AllowedPattern: '[a-z0-9-]*'
+    ConstraintDescription: Must contain only lowercase letters, numbers and hyphens (-).
+    Description: Must be a valid snapshot ID for a snapshot in the configured S3 snapshot repository, must be used in conjunction with ESBucketName set to a correctly configured bucket.
+    Type: String
   FileServerInstanceType:
     Default: m4.xlarge
     AllowedValues:
@@ -539,27 +493,78 @@ Parameters:
     AllowedValues: [General Purpose (SSD), Provisioned IOPS]
     ConstraintDescription: Must be 'General Purpose (SSD)' or 'Provisioned IOPS'.
     Type: String
-  KeyPairName:
-    ConstraintDescription: Must be the name of an existing EC2 Key Pair.
-    Description: The EC2 Key Pair to allow SSH access to the instances. If you don't provide one, the Atlassian Standard Infrastructure stack's key pair will be used.
-    Type: String
-    Default: ''
   InternetFacingLoadBalancer:
     Default: true
     AllowedValues: [true, false]
     ConstraintDescription: Must be 'true' or 'false'.
     Description: Controls whether the load balancer should be visible to the internet (true) or only within the VPC (false).
     Type: String
+  KeyPairName:
+    ConstraintDescription: Must be the name of an existing EC2 Key Pair.
+    Description: The EC2 Key Pair to allow SSH access to the instances. If you don't provide one, the Atlassian Standard Infrastructure stack's key pair will be used.
+    Type: String
+    Default: ''
   CustomDnsName:
     Default: ""
     Description: 'Use custom existing DNS name for your Data Center instance. Please note: you must own the domain and configure it to point at the load balancer.'
     Type: String
   SSLCertificateARN:
     Default: ''
-    Description: Amazon Resource Name (ARN) of your SSL certificate. If you want to use your own certificate that you generated outside of Amazon, you need to first import it to AWS Certificate Manager. After a successful import, you'll receive the ARN. If you want to create a certificate with AWS Certificate Manager (ACM certificate), you will receive the ARN after it's successfully created.
+    Description: "Amazon Resource Name (ARN) of your SSL certificate. If you want to use your own certificate that you generated outside of Amazon, you need to first import it to AWS Certificate Manager. After a successful import, you'll receive the ARN. If you want to create a certificate with AWS Certificate Manager (ACM certificate), you will receive the ARN after it's successfully created."
     MinLength: 0
     MaxLength: 90
     Type: String
+  QSS3BucketName:
+    Default: 'aws-quickstart'
+    AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
+    ConstraintDescription: Quick Start bucket name can include numbers, lowercase
+      letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen
+      (-).
+    Description: S3 bucket name for the Quick Start assets. Quick Start bucket name
+      can include numbers, lowercase letters, uppercase letters, and hyphens (-).
+      It cannot start or end with a hyphen (-).
+    Type: String
+  QSS3KeyPrefix:
+    Default: 'quickstart-atlassian-bitbucket/'
+    AllowedPattern: ^[0-9a-zA-Z-/]*$
+    ConstraintDescription: Quick Start key prefix can include numbers, lowercase letters,
+      uppercase letters, hyphens (-), and forward slash (/).
+    Description: S3 key prefix for the Quick Start assets. Quick Start key prefix
+      can include numbers, lowercase letters, uppercase letters, hyphens (-), and
+      forward slash (/).
+    Type: String
+  AvailabilityZones:
+    Description: 'List of Availability Zones to use for the subnets in the VPC. Note:
+      The logical order is preserved and only 2 AZs are used for this deployment.'
+    Type: List<AWS::EC2::AvailabilityZone::Name>
+  PrivateSubnet1CIDR:
+    Default: 10.0.0.0/19
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    Description: CIDR block for private subnet 1 located in Availability Zone 1.
+    Type: String
+  PrivateSubnet2CIDR:
+    Default: 10.0.32.0/19
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    Description: CIDR block for private subnet 2 located in Availability Zone 2.
+    Type: String
+  PublicSubnet1CIDR:
+    Default: 10.0.128.0/20
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    Description: CIDR Block for the public DMZ subnet 1 located in Availability Zone 1
+    Type: String
+  PublicSubnet2CIDR:
+    Default: 10.0.144.0/20
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    Description: CIDR Block for the public DMZ subnet 2 located in Availability Zone 2
+    Type: String
+  VPCCIDR:
+    Default: 10.0.0.0/16
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    Description: CIDR Block for the VPC
+    Type: String
+    MinValue: 100
+    MaxValue: 16384
+    Type: Number
 
 Conditions:
   GovCloudCondition: !Equals

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -40,6 +40,7 @@ Metadata:
       - Label:
           default: Database
         Parameters:
+          - DBEngine
           - DBInstanceClass
           - DBMasterUserPassword
           - DBPassword
@@ -109,6 +110,8 @@ Metadata:
         default: Elasticsearch snapshot S3 bucket name
       ESSnapshotId:
         default: Elasticsearch snapshot ID to restore
+      DBEngine:
+        default: The database engine to deploy with (PostgreSQL or Amazon Aurora PostgreSQL)
       DBInstanceClass:
         default: RDS instance class
       DBMasterUserPassword:
@@ -222,7 +225,7 @@ Parameters:
     Description: A comma-separated list of bitbucket properties in the form 'key1=value1, key2=value2, ...' Find documentation at https://confluence.atlassian.com/x/m5ZKLg
     Type: CommaDelimitedList
   BitbucketVersion:
-    Default: 6.0.0
+    Default: 6.3.1
     AllowedPattern: '([^1234]\.\d+\.\d+(-?.*))'
     ConstraintDescription: 'Must be a valid Bitbucket version number. For example: 5.0.0 or higher'
     Description: 'Version of Bitbucket to install. Please use version 5.0.0 or higher. Find valid versions at http://go.atlassian.com/bbs-releases'
@@ -383,6 +386,14 @@ Parameters:
     ConstraintDescription: Must contain only lowercase letters, numbers and hyphens (-).
     Description: Must be a valid snapshot ID for a snapshot in the configured S3 snapshot repository, must be used in conjunction with ESBucketName set to a correctly configured bucket.
     Type: String
+  DBEngine:
+    Default: 'PostgreSQL'
+    Description: 'Database Engine to use. PostgreSQL or Amazon Aurora Clustered PostgreSQL'
+    AllowedValues:
+      - 'Amazon Aurora PostgreSQL'
+      - 'PostgreSQL'
+    ConstraintDescription: Must be 'Amazon Aurora PostgreSQL' or 'PostgreSQL'.
+    Type: String
   DBInstanceClass:
     Default: db.m4.large
     AllowedValues:
@@ -402,13 +413,17 @@ Parameters:
       - db.t2.large
       - db.t2.xlarge
       - db.t2.2xlarge
+      - db.t3.medium
+      - db.t3.large
+      - db.t3.xlarge
+      - db.t3.2xlarge      
     ConstraintDescription: Must be a valid RDS instance class from the list
-    Description: RDS instance type
+    Description: RDS instance type (must be r4 family if using Aurora).
     Type: String
   DBIops:
     Default: 1000
     ConstraintDescription: Must be in the range 1000 - 30000.
-    Description: 'Must be in the range of 1000 - 30000 and a multiple of 1000. This value is only used with Provisioned IOPS. Note: The ratio of IOPS per allocated-storage must be between 3.00 and 10.00.'
+    Description: 'Must be in the range of 1000 - 30000 and a multiple of 1000. This value is only used with Provisioned IOPS. Note: The ratio of IOPS per allocated-storage must be between 3.00 and 10.00. Not valid for Aurora'
     MinValue: 1000
     MaxValue: 30000
     Type: Number
@@ -440,16 +455,16 @@ Parameters:
   DBMaster:
     Default: ''
     ConstraintDescription: Must be a valid RDS ARN.
-    Description: Database ARN of the RDS instance to replicate. Setting this parameter will bring up Bitbucket as a Disaster recovery standby, with an RDS read replica database.
+    Description: Database ARN of the RDS instance to replicate. Setting this parameter will bring up Bitbucket as a Disaster recovery standby, with an RDS read replica database. Not valid for Aurora.
     Type: String
   DBSnapshotId:
     Default: ''
     ConstraintDescription: Must be a valid RDS snapshot ID, or blank.
-    Description: RDS snapshot ID of an existing backup to restore. Must be used in conjunction with HomeVolumeSnapshotId. Leave blank for a new instance.
+    Description: RDS snapshot ID of an existing backup to restore. Must be used in conjunction with HomeVolumeSnapshotId. Leave blank for a new instance. Not valid for Aurora.
     Type: String
   DBStorage:
     Default: 10
-    Description: Database allocated storage size, in gigabytes (GB). If you choose Provisioned IOPS, storage should be between 100 and 6144
+    Description: Database allocated storage size, in gigabytes (GB). If you choose Provisioned IOPS, storage should be between 100 and 6144. Not used for Aurora.
     MinValue: 5
     MaxValue: 6144
     Type: Number
@@ -601,6 +616,7 @@ Resources:
         DBMasterUserPassword: !Ref 'DBMasterUserPassword'
         DBMultiAZ: !Ref 'DBMultiAZ'
         DBPassword: !Ref 'DBPassword'
+        DBEngine: !Ref 'DBEngine'
         DBMaster: !Ref 'DBMaster'
         DBSnapshotId: !Ref 'DBSnapshotId'
         DBStorage: !Ref 'DBStorage'

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -25,6 +25,7 @@ Metadata:
       - Label:
           default: Database
         Parameters:
+          - DBEngine
           - DBInstanceClass
           - DBIops
           - DBMasterUserPassword
@@ -84,6 +85,8 @@ Metadata:
         default: Cluster node instance type
       CreateBucket:
         default: Create S3 bucket for Elasticsearch snapshots
+      DBEngine:
+        default: The database engine to deploy with (PostgreSQL or Amazon Aurora PostgreSQL)
       DBInstanceClass:
         default: Database instance class
       DBIops:
@@ -307,6 +310,14 @@ Parameters:
     Description: "Enables CloudWatch metrics with or without log gathering. If cost is an issue, you can disable this altogether."
     AllowedValues: ["Off", "Metrics Only", "Metrics and Logs"]
     ConstraintDescription: "Must be 'Off', 'Metrics Only', or 'Metrics and Logs'"
+  DBEngine:
+    Default: 'PostgreSQL'
+    Description: 'Database Engine to use. PostgreSQL or Amazon Aurora Clustered PostgreSQL'
+    AllowedValues:
+      - 'Amazon Aurora PostgreSQL'
+      - 'PostgreSQL'
+    ConstraintDescription: Must be 'Amazon Aurora PostgreSQL' or 'PostgreSQL'.
+    Type: String
   DBInstanceClass:
     Default: db.m4.large
     AllowedValues:
@@ -331,12 +342,12 @@ Parameters:
       - db.t3.xlarge
       - db.t3.2xlarge
     ConstraintDescription: Must be a valid RDS instance class from the list
-    Description: RDS instance type
+    Description: RDS instance type  (must be r4 family if using Aurora).
     Type: String
   DBIops:
     Default: 1000
     ConstraintDescription: Must be in the range 1000 - 30000.
-    Description: 'Must be in the range of 1000 - 30000 and a multiple of 1000. This value is only used with Provisioned IOPS. Note: The ratio of IOPS per allocated-storage must be between 3.00 and 10.00.'
+    Description: 'Must be in the range of 1000 - 30000 and a multiple of 1000. This value is only used with Provisioned IOPS. Note: The ratio of IOPS per allocated-storage must be between 3.00 and 10.00. Not valid for Aurora'
     MinValue: 1000
     MaxValue: 30000
     Type: Number
@@ -368,16 +379,16 @@ Parameters:
   DBMaster:
     Default: ''
     ConstraintDescription: Must be a valid RDS ARN.
-    Description: Database ARN of the RDS instance to replicate. Setting this parameter will bring up Bitbucket as a Disaster recovery standby, with an RDS read replica database.
+    Description: Database ARN of the RDS instance to replicate. Setting this parameter will bring up Bitbucket as a Disaster recovery standby, with an RDS read replica database. Not valid for Aurora.
     Type: String
   DBSnapshotId:
     Default: ''
     ConstraintDescription: Must be a valid RDS snapshot ID, or blank.
-    Description: RDS snapshot ID of an existing backup to restore. Must be used in conjunction with HomeVolumeSnapshotId. Leave blank for a new instance.
+    Description: RDS snapshot ID of an existing backup to restore. Must be used in conjunction with HomeVolumeSnapshotId. Leave blank for a new instance. Not valid for Aurora.
     Type: String
   DBStorage:
     Default: 10
-    Description: Database allocated storage size, in gigabytes (GB). If you choose Provisioned IOPS, storage should be between 100 and 6144
+    Description: Database allocated storage size, in gigabytes (GB). If you choose Provisioned IOPS, storage should be between 100 and 6144. Not used for Aurora.
     MinValue: 5
     MaxValue: 6144
     Type: Number
@@ -567,6 +578,10 @@ Conditions:
   GovCloudCondition: !Equals
     - !Ref 'AWS::Region'
     - us-gov-west-1
+  DBEngineAurora:
+    !Equals [!Ref DBEngine, "Amazon Aurora PostgreSQL"]
+  DBEnginePostgres:
+    !Equals [!Ref DBEngine, "PostgreSQL"]
 
 Mappings:
   AWSRegionArch2AMI:
@@ -760,14 +775,15 @@ Resources:
                   - "ATL_JDBC_USER=atlbitbucket"
                   - !Sub ["ATL_JDBC_PASSWORD='${DBPassword}'", DBPassword: !Ref DBPassword]
                   - !Sub ["ATL_DB_ROOT_PASSWORD='${DBMasterUserPassword}'", DBMasterUserPassword: !Ref DBMasterUserPassword]
-                  - !Sub ["ATL_DB_HOST=${DBEndpointAddress}", DBEndpointAddress: !GetAtt DB.Endpoint.Address]
-                  - !Sub ["ATL_DB_PORT=${DBEndpointPort}", DBEndpointPort: !GetAtt DB.Endpoint.Port]
-                  - !Sub ["ATL_JDBC_URL=jdbc:postgresql://${DBEndpointAddress}:${DBEndpointPort}/confluence", { DBEndpointAddress: !GetAtt DB.Endpoint.Address, DBEndpointPort: !GetAtt DB.Endpoint.Port }]
+                  - !Sub ["ATL_DB_ENGINE=${DBEngine}", DBEngine: !If [DBEngineAurora, aurora_postgres, !If [DBEnginePostgres, rds_postgres, '']]]
+                  - !Sub ["ATL_DB_HOST=${DBEndpointAddress}", DBEndpointAddress: !If [DBEngineAurora, !GetAtt DBCluster.Outputs.RDSEndPointAddress, !GetAtt DB.Endpoint.Address]]
+                  - !Sub ["ATL_DB_PORT=${DBEndpointPort}", DBEndpointPort: !If [DBEngineAurora, !GetAtt DBCluster.Outputs.RDSEndPointPort, !GetAtt DB.Endpoint.Port]]
+                  - !Sub ["ATL_JDBC_URL=jdbc:postgresql://${DBEndpointAddress}:${DBEndpointPort}/bitbucket", { DBEndpointAddress: !If [DBEngineAurora, !GetAtt DBCluster.Outputs.RDSEndPointAddress, !GetAtt DB.Endpoint.Address], DBEndpointPort: !If [DBEngineAurora, !GetAtt DBCluster.Outputs.RDSEndPointPort, !GetAtt DB.Endpoint.Port]}]
                   - ""
-                  - !Sub ["ATL_RDS_INSTANCE_ID=${DB}", DB: !Ref "DB"]
+                  - !Sub ["ATL_RDS_INSTANCE_ID=${DB}", DB: !If [ DBEngineAurora, !Ref "DBCluster", !Ref "DB"]]
                   - !Sub ["ATL_RDS_INSTANCE_CLASS=${DBInstanceClass}", DBInstanceClass: !Ref "DBInstanceClass"]
                   - !Sub ["ATL_RDS_MULTI_AZ=${DBMultiAZ}", DBMultiAZ: !Ref "DBMultiAZ"]
-                  - !Sub ["ATL_RDS_SUBNET_GROUP_NAME=${DBSubnetGroup}", DBSubnetGroup: !Ref "DBSubnetGroup"]
+                  - !Sub ["ATL_RDS_SUBNET_GROUP_NAME=${DBSubnetGroup}", DBSubnetGroup: !If [ DBEnginePostgres, !Ref "DBSubnetGroup", '']]
                   - !Sub ["ATL_RDS_SECURITY_GROUP=${SecurityGroup}", SecurityGroup: !Ref "SecurityGroup"]
                   - ""
                   - !Sub ["ATL_NFS_DISK_VOLUME_TYPE=${VolType}", VolType: !If [IsHomeProvisionedIops, "io1", "gp2"]]
@@ -948,14 +964,14 @@ Resources:
                   - "ATL_JDBC_USER=atlbitbucket"
                   - !Sub ["ATL_JDBC_PASSWORD='${DBPassword}'", DBPassword: !Ref DBPassword]
                   - !Sub ["ATL_DB_ROOT_PASSWORD='${DBMasterUserPassword}'", DBMasterUserPassword: !Ref DBMasterUserPassword]
-                  - !Sub ["ATL_DB_HOST=${DBEndpointAddress}", DBEndpointAddress: !GetAtt DB.Endpoint.Address]
-                  - !Sub ["ATL_DB_PORT=${DBEndpointPort}", DBEndpointPort: !GetAtt DB.Endpoint.Port]
-                  - !Sub ["ATL_JDBC_URL=jdbc:postgresql://${DBEndpointAddress}:${DBEndpointPort}/confluence", { DBEndpointAddress: !GetAtt DB.Endpoint.Address, DBEndpointPort: !GetAtt DB.Endpoint.Port }]
+                  - !Sub ["ATL_DB_HOST=${DBEndpointAddress}", DBEndpointAddress: !If [ DBEngineAurora, !GetAtt DBCluster.Outputs.RDSEndPointAddress, !GetAtt DB.Endpoint.Address]]
+                  - !Sub ["ATL_DB_PORT=${DBEndpointPort}", DBEndpointPort: !If [ DBEngineAurora, !GetAtt DBCluster.Outputs.RDSEndPointPort, !GetAtt DB.Endpoint.Port]]
+                  - !Sub ["ATL_JDBC_URL=jdbc:postgresql://${DBEndpointAddress}:${DBEndpointPort}/bitbucket", { DBEndpointAddress: !If [ DBEngineAurora, !GetAtt DBCluster.Outputs.RDSEndPointAddress, !GetAtt DB.Endpoint.Address], DBEndpointPort: !If [ DBEngineAurora, !GetAtt DBCluster.Outputs.RDSEndPointPort, !GetAtt DB.Endpoint.Port] }]
                   - ""
-                  - !Sub ["ATL_RDS_INSTANCE_ID=${DB}", DB: !Ref "DB"]
+                  - !Sub ["ATL_RDS_INSTANCE_ID=${DB}", DB: !If [ DBEngineAurora, !Ref "DBCluster", !Ref "DB"]]
                   - !Sub ["ATL_RDS_INSTANCE_CLASS=${DBInstanceClass}", DBInstanceClass: !Ref "DBInstanceClass"]
                   - !Sub ["ATL_RDS_MULTI_AZ=${DBMultiAZ}", DBMultiAZ: !Ref "DBMultiAZ"]
-                  - !Sub ["ATL_RDS_SUBNET_GROUP_NAME=${DBSubnetGroup}", DBSubnetGroup: !Ref "DBSubnetGroup"]
+                  - !Sub ["ATL_RDS_SUBNET_GROUP_NAME=${DBSubnetGroup}", DBSubnetGroup: !If [ DBEnginePostgres, !Ref "DBSubnetGroup", '']]
                   - !Sub ["ATL_RDS_SECURITY_GROUP=${SecurityGroup}", SecurityGroup: !Ref "SecurityGroup"]
                   - ""
                   - !Sub ["ATL_NFS_DISK_VOLUME_TYPE=${VolType}", VolType: !If [IsHomeProvisionedIops, "io1", "gp2"]]
@@ -1058,6 +1074,7 @@ Resources:
             - !Sub [" --resource FileServer --region ${Region}\n", Region: !Ref "AWS::Region"]
   DB:
     Type: AWS::RDS::DBInstance
+    Condition: DBEnginePostgres
     Properties:
       AllocatedStorage: !Ref DBStorage
       DBInstanceClass: !Ref DBInstanceClass
@@ -1079,9 +1096,30 @@ Resources:
       VPCSecurityGroups: [!Ref SecurityGroup]
   DBSubnetGroup:
     Type: AWS::RDS::DBSubnetGroup
+    Condition: DBEnginePostgres
     Properties:
       DBSubnetGroupDescription: DBSubnetGroup
       SubnetIds: !Split [ ",", !ImportValue ATL-PriNets]
+  DBCluster:
+    Type: AWS::CloudFormation::Stack
+    Condition: DBEngineAurora
+    Properties:
+      TemplateURL: !Sub
+        - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}submodules/quickstart-atlassian-services/templates/quickstart-database-for-atlassian-services.yaml
+        - QSS3Region: !If ["GovCloudCondition", "s3-us-gov-west-1", "s3"]
+      Parameters:
+        DatabaseImplementation: !Ref DBEngine
+        DBSecurityGroup: !Ref SecurityGroup
+        DBAutoMinorVersionUpgrade: "true"
+        DBBackupRetentionPeriod: "1"
+        DBInstanceClass: !Ref DBInstanceClass
+        DBIops: !Ref DBIops
+        DBMasterUserPassword: !Ref DBMasterUserPassword
+        DBMultiAZ: !Ref DBMultiAZ
+        DBAllocatedStorage: !Ref DBStorage
+        DBStorageType: !Ref DBStorageType
+        QSS3BucketName: !Ref QSS3BucketName
+        QSS3KeyPrefix: !Ref QSS3KeyPrefix
   LoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:
@@ -1173,7 +1211,7 @@ Resources:
         ProductStackName: !Sub "${AWS::StackName}"
         ProductFamilyName: "bitbucket"
         AsgToMonitor: !Ref ClusterNodeGroup
-        DatabaseIdentifier: !Ref DB
+        DatabaseIdentifier: !If [ DBEngineAurora, !Ref DBCluster, !Ref DB ]
 
 Outputs:
   ClusterNodeGroup:
@@ -1181,10 +1219,10 @@ Outputs:
     Value: !Ref ClusterNodeGroup
   DBEndpointAddress:
     Description: The Database Connection String
-    Value: !GetAtt DB.Endpoint.Address
+    Value: !If [DBEngineAurora, !GetAtt DBCluster.Outputs.RDSEndPointAddress, !GetAtt DB.Endpoint.Address]
   DBMaster:
     Description: The RDS ARN to use when creating a Data Center standby stack
-    Value: !If [NotStandbyMode, !Sub ["arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:${DB}", {DB: !Ref "DB"}], !Ref "AWS::NoValue"]
+    Value: !If [DBEngineAurora, '', !If [NotStandbyMode, !Sub ["arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:${DB}", {DB: !Ref "DB"}], !Ref "AWS::NoValue"]]
   ServiceURL:
     Description: The URL to access this Atlassian service
     Value: !If

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -333,6 +333,12 @@ Parameters:
       - db.r4.4xlarge
       - db.r4.8xlarge
       - db.r4.16xlarge
+      - db.r5.large
+      - db.r5.xlarge
+      - db.r5.2xlarge
+      - db.r5.4xlarge
+      - db.r5.12xlarge
+      - db.r5.24xlarge
       - db.t2.medium
       - db.t2.large
       - db.t2.xlarge
@@ -342,7 +348,7 @@ Parameters:
       - db.t3.xlarge
       - db.t3.2xlarge
     ConstraintDescription: Must be a valid RDS instance class from the list
-    Description: RDS instance type (must be r4 family if using Aurora).
+    Description: RDS instance type (only r4 and r5 families are supported for Aurora).
     Type: String
   DBIops:
     Default: 1000

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: Atlassian Bitbucket Data Center QS(0034)
+Description: "Atlassian Bitbucket Data Center QS(0034)"
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -82,7 +82,7 @@ Metadata:
       ClusterNodeMin:
         default: Minimum number of cluster nodes
       ClusterNodeInstanceType:
-        default: Cluster node instance type
+        default: Bitbucket cluster node instance type
       CreateBucket:
         default: Create S3 bucket for Elasticsearch snapshots
       DBEngine:
@@ -342,7 +342,7 @@ Parameters:
       - db.t3.xlarge
       - db.t3.2xlarge
     ConstraintDescription: Must be a valid RDS instance class from the list
-    Description: RDS instance type  (must be r4 family if using Aurora).
+    Description: RDS instance type (must be r4 family if using Aurora).
     Type: String
   DBIops:
     Default: 1000
@@ -1224,7 +1224,7 @@ Outputs:
     Description: The RDS ARN to use when creating a Data Center standby stack
     Value: !If [DBEngineAurora, '', !If [NotStandbyMode, !Sub ["arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:${DB}", {DB: !Ref "DB"}], !Ref "AWS::NoValue"]]
   ServiceURL:
-    Description: The URL to access this Atlassian service
+    Description: The URL of the Bitbucket Data Center instance
     Value: !If
       - UseCustomDnsName
       - !Sub


### PR DESCRIPTION
This PR adds Aurora support to Bitbucket DC templates. All changes are in [this](https://github.com/atlassian/quickstart-atlassian-bitbucket/commit/aa996fb4ec0fc6150fba0a592180fe7c349cfde3) commit, the other one is just reformatting so the two templates look much more similar than they did earlier. 

The major difference between these and to the Jira/Confluence DC templates is the presence of separate `DB` and `DBCluster` resources. I chose to do this since Bitbucket DC supports recovering from AWS snapshots when using PostgreSQL (via the `DBSnapshotId` and the `DBMaster` parameters). Adding this to the `atlassian-quickstart-database` templates seemed wasteful, since the AWS Aurora template that we use doesn't support these parameters. We could add them in later and make our own template like we did for PostgreSQL but that's a larger piece of work that we can decide to do later on, or skip altogether considering all the other work we're doing around this.