### PR TITLE
DCD-679: did some minor edits to labels and descriptions

### DIFF
--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -15,6 +15,11 @@ Metadata:
           - ClusterNodeInstanceType
           - ClusterNodeMax
           - ClusterNodeMin
+          - DeploymentAutomationRepository
+          - DeploymentAutomationBranch
+          - DeploymentAutomationPlaybook
+          - DeploymentAutomationCustomParams
+          - DeploymentAutomationKeyName
       - Label:
           default: File server
         Parameters:
@@ -64,11 +69,9 @@ Metadata:
           - ESSnapshotId
           - HomeVolumeSnapshotId
           - HomeDeleteOnTermination
-          - DeploymentAutomationRepository
-          - DeploymentAutomationBranch
-          - DeploymentAutomationPlaybook
-          - DeploymentAutomationCustomParams
-          - DeploymentAutomationKeyName
+      - Label:
+          default: AWS Quick Start Configuration
+        Parameters:
           - QSS3BucketName
           - QSS3KeyPrefix
 
@@ -82,7 +85,7 @@ Metadata:
       JvmSupportOpts:
         default: Additional JVM options
       AccessCIDR:
-        default: Permitted IP range *
+        default: Trusted IP range *
       ClusterNodeMax:
         default: Maximum number of cluster nodes
       ClusterNodeMin:
@@ -92,7 +95,7 @@ Metadata:
       CreateBucket:
         default: Create S3 bucket for Elasticsearch snapshots
       DBEngine:
-        default: The database engine to deploy with (PostgreSQL or Amazon Aurora PostgreSQL)
+        default: The database engine to deploy with
       DBInstanceClass:
         default: Database instance class
       DBIops:
@@ -330,7 +333,7 @@ Parameters:
     ConstraintDescription: "Must be 'Off', 'Metrics Only', or 'Metrics and Logs'"
   DBEngine:
     Default: 'PostgreSQL'
-    Description: 'Database Engine to use. PostgreSQL or Amazon Aurora Clustered PostgreSQL'
+    Description: 'Database Engine to use. PostgreSQL or Amazon Aurora PostgreSQL'
     AllowedValues:
       - 'Amazon Aurora PostgreSQL'
       - 'PostgreSQL'
@@ -568,7 +571,7 @@ Parameters:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
     Description: CIDR Block for the VPC
     Type: String
-    
+
 Conditions:
   GovCloudCondition: !Equals
     - !Ref 'AWS::Region'

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -15,6 +15,11 @@ Metadata:
           - ClusterNodeInstanceType
           - ClusterNodeMax
           - ClusterNodeMin
+          - DeploymentAutomationRepository
+          - DeploymentAutomationBranch
+          - DeploymentAutomationPlaybook
+          - DeploymentAutomationKeyName
+          - DeploymentAutomationCustomParams
       - Label:
           default: File server
         Parameters:
@@ -58,11 +63,9 @@ Metadata:
           - ESSnapshotId
           - HomeVolumeSnapshotId
           - HomeDeleteOnTermination
-          - DeploymentAutomationRepository
-          - DeploymentAutomationBranch
-          - DeploymentAutomationPlaybook
-          - DeploymentAutomationCustomParams
-          - DeploymentAutomationKeyName
+      - Label:
+          default: AWS Quick Start Configuration
+        Parameters:
           - QSS3BucketName
           - QSS3KeyPrefix
 
@@ -86,7 +89,7 @@ Metadata:
       CreateBucket:
         default: Create S3 bucket for Elasticsearch snapshots
       DBEngine:
-        default: The database engine to deploy with (PostgreSQL or Amazon Aurora PostgreSQL)
+        default: The database engine to deploy with
       DBInstanceClass:
         default: Database instance class
       DBIops:
@@ -312,7 +315,7 @@ Parameters:
     ConstraintDescription: "Must be 'Off', 'Metrics Only', or 'Metrics and Logs'"
   DBEngine:
     Default: 'PostgreSQL'
-    Description: 'Database Engine to use. PostgreSQL or Amazon Aurora Clustered PostgreSQL'
+    Description: 'Database Engine to use. PostgreSQL or Amazon Aurora PostgreSQL'
     AllowedValues:
       - 'Amazon Aurora PostgreSQL'
       - 'PostgreSQL'


### PR DESCRIPTION
Mainly, edited for consistency with Jira templates

- S3 bucket configs now have separate label (`AWS Quick Start Configuration`)
- Ansible parameters are now under `Cluster nodes` label
- other minor things