### PR TITLE
DCD-466: Expand Security Group to include NAT gateways IPs

### DIFF
--- a/ci/params/default/quickstart-bitbucket-default.json
+++ b/ci/params/default/quickstart-bitbucket-default.json
@@ -34,9 +34,17 @@
   {
     "ParameterKey": "ClusterNodeInstanceType",
     "ParameterValue": "t3.medium"
-},
-{
+  },
+  {
     "ParameterKey": "DBInstanceClass",
     "ParameterValue": "db.t3.medium"
-}
+  },
+  {
+    "ParameterKey": "QSS3BucketName",
+    "ParameterValue": "$[taskcat_autobucket]"
+  },
+  {
+    "ParameterKey": "QSS3KeyPrefix",
+    "ParameterValue": "quickstart-atlassian-services/"
+  }
 ]

--- a/ci/params/default/quickstart-bitbucket-default.json
+++ b/ci/params/default/quickstart-bitbucket-default.json
@@ -5,7 +5,7 @@
   },
   {
     "ParameterKey": "BitbucketVersion",
-    "ParameterValue": "6.6.0"
+    "ParameterValue": "6.8.1"
   },
   {
     "ParameterKey": "DBMasterUserPassword",
@@ -14,10 +14,6 @@
   {
     "ParameterKey": "CidrBlock",
     "ParameterValue": "0.0.0.0/0"
-  },
-  {
-    "ParameterKey": "DBInstanceClass",
-    "ParameterValue": "db.t2.large"
   },
   {
     "ParameterKey": "DBIops",

--- a/ci/params/default/quickstart-bitbucket-default.json
+++ b/ci/params/default/quickstart-bitbucket-default.json
@@ -45,6 +45,6 @@
   },
   {
     "ParameterKey": "QSS3KeyPrefix",
-    "ParameterValue": "quickstart-atlassian-services/"
+    "ParameterValue": "quickstart-atlassian-bitbucket/"
   }
 ]

--- a/ci/params/ssl-and-dns/quickstart-bitbucket-ci-params.json
+++ b/ci/params/ssl-and-dns/quickstart-bitbucket-ci-params.json
@@ -46,5 +46,13 @@
     {
         "ParameterKey": "DBInstanceClass",
         "ParameterValue": "db.t3.medium"
+    },
+    {
+        "ParameterKey": "QSS3BucketName",
+        "ParameterValue": "$[taskcat_autobucket]"
+    },
+    {
+        "ParameterKey": "QSS3KeyPrefix",
+        "ParameterValue": "quickstart-atlassian-services/"
     }
 ]

--- a/ci/params/ssl-and-dns/quickstart-bitbucket-ci-params.json
+++ b/ci/params/ssl-and-dns/quickstart-bitbucket-ci-params.json
@@ -53,6 +53,6 @@
     },
     {
         "ParameterKey": "QSS3KeyPrefix",
-        "ParameterValue": "quickstart-atlassian-services/"
+        "ParameterValue": "quickstart-atlassian-bitbucket/"
     }
 ]

--- a/ci/quickstart-bitbucket-master.json
+++ b/ci/quickstart-bitbucket-master.json
@@ -16,6 +16,10 @@
         "ParameterValue": "10.0.0.0/0"
     },
     {
+        "ParameterKey": "DBMultiAZ",
+        "ParameterValue": "false"
+    },
+    {
         "ParameterKey": "DBInstanceClass",
         "ParameterValue": "db.t2.large"
     },
@@ -38,5 +42,9 @@
     {
         "ParameterKey":"QSS3KeyPrefix",
         "ParameterValue":"quickstart-atlassian-bitbucket/"
+    },
+    {
+        "ParameterKey": "ExportPrefix",
+        "ParameterValue": "$[taskcat_random-string]"
     }
 ]

--- a/ci/taskcat.yml
+++ b/ci/taskcat.yml
@@ -21,6 +21,6 @@ global:
 tests:
   BB-5:
     template_file: quickstart-bitbucket-dc-with-vpc.template.yaml
-    parameter_input: quickstart-bitbucket-master-v5.json
+    parameter_input: quickstart-bitbucket-master.json
     regions:
-     - us-west-1
+      - us-west-1

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -74,6 +74,7 @@ Metadata:
         Parameters:
           - QSS3BucketName
           - QSS3KeyPrefix
+          - ExportPrefix
 
     ParameterLabels:
       BitbucketProperties:
@@ -132,6 +133,8 @@ Metadata:
         default: Elasticsearch snapshot S3 bucket name
       ESSnapshotId:
         default: Elasticsearch snapshot ID to restore
+      ExportPrefix:
+        default: ASI Exported Prefix
       FileServerInstanceType:
         default: File server instance type
       HomeDeleteOnTermination:
@@ -455,6 +458,11 @@ Parameters:
     ConstraintDescription: Must contain only lowercase letters, numbers and hyphens (-).
     Description: Must be a valid snapshot ID for a snapshot in the configured S3 snapshot repository, must be used in conjunction with ESBucketName set to a correctly configured bucket.
     Type: String
+  ExportPrefix:
+    Default: 'ATL-'
+    Description:
+      Prefix for the exported variables (VPCID, SubnetIDs, KeyName) that are reused by other Atlassian AWS Quickstarts.
+    Type: String
   FileServerInstanceType:
     Default: m4.xlarge
     AllowedValues:
@@ -591,6 +599,7 @@ Resources:
         AvailabilityZones: !Join
           - ','
           - !Ref 'AvailabilityZones'
+        ExportPrefix: !Ref ExportPrefix
         KeyPairName: !Ref 'KeyPairName'
         PrivateSubnet1CIDR: !Ref 'PrivateSubnet1CIDR'
         PrivateSubnet2CIDR: !Ref 'PrivateSubnet2CIDR'
@@ -613,8 +622,6 @@ Resources:
           - ','
           - !Ref 'BitbucketProperties'
         BitbucketVersion: !Ref 'BitbucketVersion'
-        JvmHeapOverride: !Ref 'JvmHeapOverride'
-        JvmSupportOpts: !Ref 'JvmSupportOpts'
         CidrBlock: !Ref 'AccessCIDR'
         CloudWatchIntegration: !Ref 'CloudWatchIntegration'
         ClusterNodeInstanceType: !Ref 'ClusterNodeInstanceType'
@@ -637,6 +644,7 @@ Resources:
         DeploymentAutomationPlaybook: !Ref 'DeploymentAutomationPlaybook'
         DeploymentAutomationKeyName: !Ref 'DeploymentAutomationKeyName'
         DeploymentAutomationCustomParams: !Ref 'DeploymentAutomationCustomParams'
+        ExportPrefix: !Ref ExportPrefix
         ElasticsearchInstanceType: !Ref 'ElasticsearchInstanceType'
         ESBucketName: !Ref 'ESBucketName'
         ESSnapshotId: !Ref 'ESSnapshotId'
@@ -646,6 +654,8 @@ Resources:
         HomeSize: !Ref 'HomeSize'
         HomeVolumeSnapshotId: !Ref 'HomeVolumeSnapshotId'
         HomeVolumeType: !Ref 'HomeVolumeType'
+        JvmHeapOverride: !Ref 'JvmHeapOverride'
+        JvmSupportOpts: !Ref 'JvmSupportOpts'
         KeyPairName: !Ref 'KeyPairName'
         SSLCertificateARN: !Ref 'SSLCertificateARN'
 

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -461,7 +461,7 @@ Parameters:
   ExportPrefix:
     Default: 'ATL-'
     Description:
-      Identifier used in all variables exported from this deployment’s Atlassian Standard Infrastructure (VPCID, SubnetIDs, KeyName). Use different identifier to deploy multiple Atlassian Standard Infrastructures in the same AWS region.
+      Identifier used in all variables (VPCID, SubnetIDs, KeyName) exported from this deployment's Atlassian Standard Infrastructure. Use different identifiers if you're deploying multiple Atlassian Standard Infrastructures in the same AWS region.
     Type: String
   FileServerInstanceType:
     Default: m4.xlarge

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -461,7 +461,7 @@ Parameters:
   ExportPrefix:
     Default: 'ATL-'
     Description:
-      Prefix for the exported variables (VPCID, SubnetIDs, KeyName) that are reused by other Atlassian AWS Quickstarts.
+      Identifier used in all variables exported from this deployment’s Atlassian Standard Infrastructure (VPCID, SubnetIDs, KeyName). Use different identifier to deploy multiple Atlassian Standard Infrastructures in the same AWS region.
     Type: String
   FileServerInstanceType:
     Default: m4.xlarge

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -866,9 +866,9 @@ Resources:
             - "#!/bin/bash -xe\n"
             - "yum update -y aws-cfn-bootstrap amazon-ssm-agent\n"
             - !Sub "/opt/aws/bin/cfn-init -v --stack ${AWS::StackName}"
-            - !Sub " --resource FileServer --region ${AWS::Region}\n"
+            - !Sub " --resource ClusterNodeLaunchConfig --region ${AWS::Region}\n"
             - !Sub "/opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName}"
-            - !Sub "--resource FileServer --region ${AWS::Region}\n"
+            - !Sub " --resource ClusterNodeGroup --region ${AWS::Region}\n"
   ClusterNodeScaleUpPolicy:
     Type: AWS::AutoScaling::ScalingPolicy
     Properties:

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -75,10 +75,6 @@ Metadata:
         default: Bitbucket properties
       BitbucketVersion:
         default: Version *
-      JvmHeapOverride:
-        default: JVM Heap Size Override
-      JvmSupportOpts:
-        default: Additional JVM options
       CidrBlock:
         default: Permitted IP range *
       ClusterNodeMax:
@@ -128,7 +124,7 @@ Metadata:
       ESSnapshotId:
         default: Elasticsearch snapshot ID to restore
       ExportPrefix:
-        default: ASI Exported Prefix
+        default: ASI identifier
       FileServerInstanceType:
         default: File server instance type
       HomeDeleteOnTermination:
@@ -143,6 +139,10 @@ Metadata:
         default: Home directory volume type
       InternetFacingLoadBalancer:
         default: Make instance internet facing
+      JvmHeapOverride:
+        default: JVM Heap Size Override
+      JvmSupportOpts:
+        default: Additional JVM options
       KeyPairName:
         default: SSH Key Pair Name
       CustomDnsName:
@@ -164,14 +164,6 @@ Parameters:
     AllowedPattern: '([^1234]\.\d+\.\d+(-?.*))'
     ConstraintDescription: 'Must be a valid Bitbucket version number. For example: 5.0.0 or higher'
     Description: 'Version of Bitbucket to install. Please use version 5.0.0 or higher. Find valid versions at http://go.atlassian.com/bbs-releases'
-    Type: String
-  JvmHeapOverride:
-    Default: ''
-    Description: Override the default amount of memory to allocate to the JVM for your instance type - set size in meg or gig e.g. 1024m or 1g
-    Type: String
-  JvmSupportOpts:
-    Default: ''
-    Description: Pass in any additional JVM options to tune the Bitbucket instance
     Type: String
   CidrBlock:
     AllowedPattern: '(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})'
@@ -443,7 +435,7 @@ Parameters:
   ExportPrefix:
     Default: 'ATL-'
     Description:
-      Prefix for the exported variables (VPCID, SubnetIDs, KeyName) that are reused by other Atlassian AWS Quickstarts.
+      Each Atlassian Standard Infrastructure (ASI) uses a unique identifier. If you have multiple ASIs within the same AWS region, use this field to specify where to deploy Bitbucket.
     Type: String
   FileServerInstanceType:
     Default: m4.xlarge
@@ -497,6 +489,14 @@ Parameters:
     AllowedValues: [true, false]
     ConstraintDescription: Must be 'true' or 'false'.
     Description: Controls whether the load balancer should be visible to the internet (true) or only within the VPC (false).
+    Type: String
+  JvmHeapOverride:
+    Default: ''
+    Description: Override the default amount of memory to allocate to the JVM for your instance type - set size in meg or gig e.g. 1024m or 1g
+    Type: String
+  JvmSupportOpts:
+    Default: ''
+    Description: Pass in any additional JVM options to tune the Bitbucket instance
     Type: String
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -68,6 +68,7 @@ Metadata:
         Parameters:
           - QSS3BucketName
           - QSS3KeyPrefix
+          - ExportPrefix
 
     ParameterLabels:
       BitbucketProperties:
@@ -126,6 +127,8 @@ Metadata:
         default: Elasticsearch snapshot S3 bucket name
       ESSnapshotId:
         default: Elasticsearch snapshot ID to restore
+      ExportPrefix:
+        default: ASI Exported Prefix
       FileServerInstanceType:
         default: File server instance type
       HomeDeleteOnTermination:
@@ -437,6 +440,11 @@ Parameters:
     ConstraintDescription: Must contain only lowercase letters, numbers and hyphens (-).
     Description: Must be a valid snapshot ID for a snapshot in the configured S3 snapshot repository, must be used in conjunction with ESBucketName set to a correctly configured bucket.
     Type: String
+  ExportPrefix:
+    Default: 'ATL-'
+    Description:
+      Prefix for the exported variables (VPCID, SubnetIDs, KeyName) that are reused by other Atlassian AWS Quickstarts.
+    Type: String
   FileServerInstanceType:
     Default: m4.xlarge
     AllowedValues:
@@ -596,52 +604,40 @@ Mappings:
   AWSRegionArch2AMI:
     ap-northeast-1:
       HVM64: ami-0c3fd0f5d33134a76
-      HVMG2: NOT_SUPPORTED
     ap-northeast-2:
       HVM64: ami-095ca789e0549777d
-      HVMG2: NOT_SUPPORTED
     ap-south-1:
       HVM64: ami-0d2692b6acea72ee6
-      HVMG2: NOT_SUPPORTED
     ap-southeast-1:
       HVM64: ami-01f7527546b557442
-      HVMG2: NOT_SUPPORTED
     ap-southeast-2:
       HVM64: ami-0dc96254d5535925f
-      HVMG2: NOT_SUPPORTED
     ca-central-1:
       HVM64: ami-0d4ae09ec9361d8ac
-      HVMG2: NOT_SUPPORTED
     eu-central-1:
       HVM64: ami-0cc293023f983ed53
-      HVMG2: NOT_SUPPORTED
     eu-north-1:
       HVM64: ami-3f36be41
-      HVMG2: NOT_SUPPORTED
     eu-west-1:
       HVM64: ami-0bbc25e23a7640b9b
-      HVMG2: NOT_SUPPORTED
     eu-west-2:
       HVM64: ami-0d8e27447ec2c8410
-      HVMG2: NOT_SUPPORTED
     eu-west-3:
       HVM64: ami-0adcddd3324248c4c
-      HVMG2: NOT_SUPPORTED
     sa-east-1:
       HVM64: ami-058943e7d9b9cabfb
-      HVMG2: NOT_SUPPORTED
     us-east-1:
       HVM64: ami-0b898040803850657
-      HVMG2: NOT_SUPPORTED
     us-east-2:
       HVM64: ami-0d8f6eb4f641ef691
-      HVMG2: NOT_SUPPORTED
     us-west-1:
       HVM64: ami-056ee704806822732
-      HVMG2: NOT_SUPPORTED
     us-west-2:
       HVM64: ami-082b5a644766e0e6f
-      HVMG2: NOT_SUPPORTED
+    us-gov-west-1:
+      HVM64: ami-e9a9d388
+    us-gov-east-1:
+      HVM64: ami-a2d938d3
 
 Resources:
   BitbucketFileServerRole:
@@ -657,8 +653,8 @@ Resources:
                 - es.amazonaws.com
             Action: ['sts:AssumeRole']
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM
-        - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy"
       Path: /
       Policies:
         - PolicyName: BitbucketFileServerPolicy
@@ -698,8 +694,8 @@ Resources:
                     - 's3:ListBucket'
                     - 's3:PutObject'
                   Resource:
-                    - !Sub ["arn:aws:s3:::${BucketName}", BucketName: !Ref ESBucketName]
-                    - !Sub ["arn:aws:s3:::${BucketName}/*", BucketName: !Ref ESBucketName]
+                    - !Sub "arn:${AWS::Partition}:s3:::${ESBucketName}"
+                    - !Sub "arn:${AWS::Partition}:s3:::${ESBucketName}/*"
                 - !Ref "AWS::NoValue"
   BitbucketClusterNodeRole:
     Type: AWS::IAM::Role
@@ -712,7 +708,7 @@ Resources:
               Service: [ec2.amazonaws.com]
             Action: ['sts:AssumeRole']
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
       Path: /
       Policies:
         - PolicyName: BitbucketClusterNodePolicy
@@ -740,10 +736,12 @@ Resources:
       MinSize: !If [StandbyMode, '0', !Ref ClusterNodeMin]
       MaxSize: !Ref ClusterNodeMax
       LoadBalancerNames: [!Ref LoadBalancer]
-      VPCZoneIdentifier: !Select [0, [!Split [ ',', !ImportValue ATL-PriNets]]]
+      VPCZoneIdentifier: !Split
+        - ","
+        - Fn::ImportValue: !Sub "${ExportPrefix}PriNets"
       Tags:
         - Key: Name
-          Value: !Sub ["${StackName} Bitbucket Node", StackName: !Ref 'AWS::StackName']
+          Value: !Sub "${AWS::StackName} Bitbucket Node"
           PropagateAtLaunch: true
         - Key: Cluster
           Value: !Ref AWS::StackName
@@ -848,7 +846,10 @@ Resources:
 
     Properties:
       AssociatePublicIpAddress: false
-      KeyName: !If [ KeyProvided, !Ref KeyPairName, !ImportValue ATL-DefaultKey ]
+      KeyName: !If
+        - KeyProvided
+        - !Ref KeyPairName
+        - Fn::ImportValue: !Sub "${ExportPrefix}DefaultKey"
       IamInstanceProfile: !Ref BitbucketClusterNodeInstanceProfile
       ImageId:
         !FindInMap
@@ -864,10 +865,10 @@ Resources:
           -
             - "#!/bin/bash -xe\n"
             - "yum update -y aws-cfn-bootstrap amazon-ssm-agent\n"
-            - !Sub ["/opt/aws/bin/cfn-init -v --stack ${StackName}", StackName: !Ref "AWS::StackName"]
-            - !Sub [" --resource ClusterNodeLaunchConfig --region ${Region}\n", Region: !Ref "AWS::Region"]
-            - !Sub ["/opt/aws/bin/cfn-signal -e $? --stack ${StackName}", StackName: !Ref "AWS::StackName"]
-            - !Sub [" --resource ClusterNodeGroup --region ${Region}", Region: !Ref "AWS::Region"]
+            - !Sub "/opt/aws/bin/cfn-init -v --stack ${AWS::StackName}"
+            - !Sub " --resource FileServer --region ${AWS::Region}\n"
+            - !Sub "/opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName}"
+            - !Sub "--resource FileServer --region ${AWS::Region}\n"
   ClusterNodeScaleUpPolicy:
     Type: AWS::AutoScaling::ScalingPolicy
     Properties:
@@ -932,7 +933,7 @@ Resources:
             Resource: "*"
       Tags:
         - Key: Name
-          Value: !Sub ["${StackName} Bitbucket Elasticsearch cluster", StackName: !Ref 'AWS::StackName']
+          Value: !Sub "${AWS::StackName} Bitbucket Elasticsearch cluster"
         - Key: Application
           Value: !Ref "AWS::StackId"
   ElasticsearchBucket:
@@ -1057,16 +1058,23 @@ Resources:
         - !Ref "AWS::Region"
         - HVM64
       InstanceType: !Ref FileServerInstanceType
-      KeyName: !If [ KeyProvided, !Ref KeyPairName, !ImportValue ATL-DefaultKey ]
+      KeyName: !If
+        - KeyProvided
+        - !Ref KeyPairName
+        - Fn::ImportValue: !Sub "${ExportPrefix}DefaultKey"
       NetworkInterfaces:
         - GroupSet: [!Ref SecurityGroup]
           AssociatePublicIpAddress: false
           DeviceIndex: '0'
           DeleteOnTermination: true
-          SubnetId: !Select [0, !Split [ ",", !ImportValue ATL-PriNets] ]
+          SubnetId: !Select
+            - 0
+            - !Split
+              - ","
+              - Fn::ImportValue: !Sub "${ExportPrefix}PriNets"
       Tags:
         - Key: Name
-          Value: !Sub ["${StackName} Bitbucket NFS Server", StackName: !Ref 'AWS::StackName']
+          Value: !Sub "${AWS::StackName} Bitbucket NFS Server"
         - Key: Application
           Value:
             !Ref "AWS::StackId"
@@ -1101,14 +1109,16 @@ Resources:
       SourceDBInstanceIdentifier: !If [StandbyMode, !Ref DBMaster, !Ref "AWS::NoValue"]
       Tags:
         - Key: Name
-          Value: !Sub ["${StackName} Bitbucket PostgreSQL Database", StackName: !Ref 'AWS::StackName']
+          Value: !Sub "${AWS::StackName} Bitbucket PostgreSQL Database"
       VPCSecurityGroups: [!Ref SecurityGroup]
   DBSubnetGroup:
     Type: AWS::RDS::DBSubnetGroup
     Condition: DBEnginePostgres
     Properties:
       DBSubnetGroupDescription: DBSubnetGroup
-      SubnetIds: !Split [ ",", !ImportValue ATL-PriNets]
+      SubnetIds: !Split
+        - ","
+        - Fn::ImportValue: !Sub "${ExportPrefix}PriNets"
   DBCluster:
     Type: AWS::CloudFormation::Stack
     Condition: DBEngineAurora
@@ -1127,6 +1137,7 @@ Resources:
         DBMultiAZ: !Ref DBMultiAZ
         DBAllocatedStorage: !Ref DBStorage
         DBStorageType: !Ref DBStorageType
+        ExportPrefix: !Ref ExportPrefix
         QSS3BucketName: !Ref QSS3BucketName
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
   LoadBalancer:
@@ -1169,10 +1180,12 @@ Resources:
         UnhealthyThreshold: '2'
       Scheme: !If [UsePublicIp, 'internet-facing', 'internal']
       SecurityGroups: [!Ref SecurityGroup]
-      Subnets: !Split [ ",", !ImportValue ATL-PubNets]
+      Subnets: !Split
+        - ","
+        - Fn::ImportValue: !Sub "${ExportPrefix}PubNets"
       Tags:
         - Key: Name
-          Value: !Sub ["${StackName} LoadBalancer", StackName: !Ref 'AWS::StackName']
+          Value: !Sub "${AWS::StackName} LoadBalancer"
         - Key: Cluster
           Value: !Ref AWS::StackName
   SecurityGroup:
@@ -1196,10 +1209,43 @@ Resources:
           FromPort: 7999
           ToPort: 7999
           CidrIp: !Ref CidrBlock
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp:
+            !Sub
+            - "${NAT1IP}/32"
+            - NAT1IP:
+                Fn::ImportValue: !Sub '${ExportPrefix}NAT1EIP'
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp:
+            !Sub
+            - "${NAT2IP}/32"
+            - NAT2IP:
+                Fn::ImportValue: !Sub '${ExportPrefix}NAT2EIP'
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp:
+            !Sub
+            - "${NAT1IP}/32"
+            - NAT1IP:
+                Fn::ImportValue: !Sub '${ExportPrefix}NAT1EIP'
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp:
+            !Sub
+            - "${NAT2IP}/32"
+            - NAT2IP:
+                Fn::ImportValue: !Sub '${ExportPrefix}NAT2EIP'
       Tags:
         - Key: Name
           Value: !Join [' ', [!Ref 'AWS::StackName', sg]]
-      VpcId: !ImportValue ATL-VPCID
+      VpcId:
+        Fn::ImportValue: !Sub "${ExportPrefix}VPCID"
   SecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
@@ -1231,7 +1277,7 @@ Outputs:
     Value: !If [DBEngineAurora, !GetAtt DBCluster.Outputs.RDSEndPointAddress, !GetAtt DB.Endpoint.Address]
   DBMaster:
     Description: The RDS ARN to use when creating a Data Center standby stack
-    Value: !If [DBEngineAurora, '', !If [NotStandbyMode, !Sub ["arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:${DB}", {DB: !Ref "DB"}], !Ref "AWS::NoValue"]]
+    Value: !If [DBEngineAurora, '', !If [NotStandbyMode, !Sub ["arn:${AWS::Partition}:rds:${AWS::Region}:${AWS::AccountId}:db:${DB}", {DB: !Ref "DB"}], !Ref "AWS::NoValue"]]
   ServiceURL:
     Description: The URL of the Bitbucket Data Center instance
     Value: !If


### PR DESCRIPTION
* Add NAT Gateway IPs to security group
* Add support for Export Prefix (ASI identifier)
* Add initial support for GovCloud
* Fix taskcat test properties (include QS prefix and S3 bucket)