### PR TITLE
DCD-979: Create custom resource for generating db instance name when DB is postgres

### DIFF
--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -1,0 +1,35 @@
+project:
+  name: quickstart-atlassian-bitbucket
+  owner: quickstart-eng@amazon.com
+  package_lambda: false
+  regions:
+  - ap-northeast-1
+  - ap-northeast-2
+  - ap-south-1
+  - ap-southeast-1
+  - ap-southeast-2
+  - eu-central-1
+  - eu-west-1
+  - sa-east-1
+  - us-east-1
+  - us-east-2
+  - us-west-1
+  - us-west-2
+  s3_bucket: ''
+tests:
+  BB-5:
+    parameters:
+      CidrBlock: 10.0.0.0/0
+      BitbucketVersion: 6.6.0
+      DBInstanceClass: db.t2.large
+      DBIops: '1000'
+      DBMasterUserPassword: f925dO1ry_
+      DBMultiAZ: 'false'
+      DBPassword: f925dO1ry_
+      KeyPairName: replaced-by-taskcat-override-file
+      QSS3BucketName: $[taskcat_autobucket]
+      QSS3KeyPrefix: quickstart-atlassian-bitbucket/
+    regions:
+    - us-east-1
+    s3_bucket: ''
+    template: templates/quickstart-bitbucket-dc.template.yaml

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -1115,13 +1115,64 @@ Resources:
             - !Sub [" --resource FileServer --region ${Region}\n", Region: !Ref "AWS::Region"]
             - !Sub ["/opt/aws/bin/cfn-signal -e $? --stack ${StackName}", StackName: !Ref "AWS::StackName"]
             - !Sub [" --resource FileServer --region ${Region}\n", Region: !Ref "AWS::Region"]
+
+  ## We need a custom resource to generate a meaningful name. If the stack name
+  ## is longer than 57 characters, using {StackName}-db would cause a deployment failure
+  DbInstanceName:
+    Condition: DBEnginePostgres
+    Type: Custom::DbInstanceName
+    Version: 1.0
+    Properties:
+      ServiceToken: !GetAtt DBNameGenerator.Arn
+      StackName: !Ref 'AWS::StackName'
+  DBNameGenerator:
+    Condition: DBEnginePostgres
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Handler: index.lambda_handler
+      Role: !GetAtt DBNameGeneratorExecutionRole.Arn
+      Runtime: python3.7
+      Timeout: 120
+      Code:
+        ZipFile: |
+          import cfnresponse
+          def lambda_handler(event, context):
+            stack_name = event['ResourceProperties']['StackName']
+            responseData = {}
+            responseData['DBInstanceName'] = stack_name[:57] + "-db"
+            cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)
+  DBNameGeneratorExecutionRole:
+    Condition: DBEnginePostgres
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - lambda.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Path: "/"
+      Policies:
+      - PolicyName: root
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - logs:CreateLogGroup
+            - logs:CreateLogStream
+            - logs:PutLogEvents
+            Resource: !Sub "arn:aws:logs:*:${AWS::AccountId}:log-group:/aws/lambda/*DBNameGenerator*"
   DB:
     Type: AWS::RDS::DBInstance
     Condition: DBEnginePostgres
     Properties:
       AllocatedStorage: !Ref DBStorage
       DBInstanceClass: !Ref DBInstanceClass
-      DBInstanceIdentifier: !Ref AWS::StackName
+      DBInstanceIdentifier: !GetAtt DbInstanceName.DBInstanceName
       DBName: !If [RestoreRDSOrStandby, !Ref "AWS::NoValue", bitbucket]
       DBSnapshotIdentifier: !If [RestoreFromRDSSnapshot, !Ref DBSnapshotId, !Ref "AWS::NoValue"]
       DBSubnetGroupName: !Ref DBSubnetGroup


### PR DESCRIPTION
Bitbucket does not use Atlassian Services DB template for db so I had to copy the custom resource over here.

I did not want to change the bitbucket template to use the nested stack for both DB's as it would be a breaking change in the template.

See https://github.com/atlassian/quickstart-atlassian-services/pull/32 for context.