### PR TITLE
DCD-948: Bastion host usage should be optional

### DIFF
--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -563,7 +563,7 @@ Parameters:
     Type: String
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
-    Description: The EC2 Key Pair to allow SSH access to the instances.
+    Description: Public/private EC2 Key Pairs to allow you to securely access the Bastion host
     Type: String
     Default: ''
   CustomDnsName:

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -42,6 +42,7 @@ Metadata:
           default: Bastion host provisioning
           Parameters:
             - BastionHostRequired
+            - KeyPairName
       - Label:
           default: Elasticsearch
         Parameters:
@@ -52,7 +53,6 @@ Metadata:
         Parameters:
           - AccessCIDR
           - InternetFacingLoadBalancer
-          - KeyPairName
           - CustomDnsName
           - SSLCertificateARN
           - VPCCIDR

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -559,7 +559,7 @@ Parameters:
     AllowedValues:
       - "true"
       - "false"
-    Description: Whether to provision a Bastion host instance. If 'true', then you need to provide an EC2 Key Pair (otherwise, you won't be able to use the Bastion host to access Crowd instances).
+    Description: Whether to provision a Bastion host instance. If 'true', then you need to provide an EC2 Key Pair (otherwise, you won't be able to use the Bastion host to access BitBucket instances).
     Type: String
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -39,6 +39,10 @@ Metadata:
           - DBStorage
           - DBStorageType
       - Label:
+          default: Bastion host provisioning
+          Parameters:
+            - BastionHostRequired
+      - Label:
           default: Elasticsearch
         Parameters:
           - ElasticsearchInstanceType
@@ -161,6 +165,8 @@ Metadata:
         default: Home directory volume type
       InternetFacingLoadBalancer:
         default: Make instance internet facing
+      BastionHostRequired:
+        default: Deploy Bastion host
       KeyPairName:
         default: SSH Key Pair Name
       CustomDnsName:
@@ -197,12 +203,12 @@ Parameters:
     Type: String
   BitbucketLicenseKey:
     Default: ''
-    Description: Provide a license key for Bitbucket Data Center if you have one. 
+    Description: Provide a license key for Bitbucket Data Center if you have one.
     Type: String
   BitbucketAdminPassword:
-    AllowedPattern: '((?=^.{0,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*)|(^$)'    
+    AllowedPattern: '((?=^.{0,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*)|(^$)'
     ConstraintDescription: Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
-    Description: (Optional) Password for the Bitbucket administrator ('admin') account. 
+    Description: (Optional) Password for the Bitbucket administrator ('admin') account.
     MaxLength: 128
     NoEcho: true
     Type: String
@@ -548,10 +554,17 @@ Parameters:
     ConstraintDescription: Must be 'true' or 'false'.
     Description: Controls whether the load balancer should be visible to the internet (true) or only within the VPC (false).
     Type: String
+  BastionHostRequired:
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: Whether to provision a Bastion host instance. If 'true', then you need to provide an EC2 Key Pair (otherwise, you won't be able to use the Bastion host to access Crowd instances).
+    Type: String
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
     Description: The EC2 Key Pair to allow SSH access to the instances.
-    Type: AWS::EC2::KeyPair::KeyName
+    Type: String
     Default: ''
   CustomDnsName:
     Default: ""
@@ -616,6 +629,11 @@ Conditions:
   GovCloudCondition: !Equals
     - !Ref 'AWS::Region'
     - us-gov-west-1
+  KeyProvided:
+    !Not [!Equals [!Ref KeyPairName, '']]
+  ProvisionBastion: !And
+    - !Equals [!Ref BastionHostRequired, true]
+    - !Condition KeyProvided
 Resources:
   VPCStack:
     Type: AWS::CloudFormation::Stack
@@ -638,6 +656,8 @@ Resources:
         PublicSubnet1CIDR: !Ref 'PublicSubnet1CIDR'
         PublicSubnet2CIDR: !Ref 'PublicSubnet2CIDR'
         VPCCIDR: !Ref 'VPCCIDR'
+        BastionHostRequired: !Ref 'BastionHostRequired'
+
   BitbucketDCStack:
     DependsOn: VPCStack
     Type: AWS::CloudFormation::Stack
@@ -694,6 +714,7 @@ Resources:
         JvmSupportOpts: !Ref 'JvmSupportOpts'
         KeyPairName: !Ref 'KeyPairName'
         SSLCertificateARN: !Ref 'SSLCertificateARN'
+        BastionHostRequired: !Ref 'BastionHostRequired'
 
 Outputs:
   ClusterNodeGroup:
@@ -712,5 +733,6 @@ Outputs:
     Description: The name of the SecurityGroup
     Value: !GetAtt 'BitbucketDCStack.Outputs.SGname'
   BastionPubIp:
+    Condition: ProvisionBastion
     Description: The Public IP to ssh to the Bastion
     Value: !GetAtt 'VPCStack.Outputs.BastionPubIp'

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -159,7 +159,7 @@ Metadata:
       JvmSupportOpts:
         default: Additional JVM options
       BastionHostRequired:
-        default: Enable Bastion host usage
+        default: Use Bastion host
       KeyPairName:
         default: SSH Key Pair Name
       CustomDnsName:

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -42,6 +42,7 @@ Metadata:
           default: Bastion host utilization
           Parameters:
             - BastionHostRequired
+            - KeyPairName
       - Label:
           default: Elasticsearch
         Parameters:
@@ -52,7 +53,6 @@ Metadata:
         Parameters:
           - CidrBlock
           - InternetFacingLoadBalancer
-          - KeyPairName
           - CustomDnsName
           - SSLCertificateARN
       - Label:

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -39,6 +39,10 @@ Metadata:
           - DBStorage
           - DBStorageType
       - Label:
+          default: Bastion host utilization
+          Parameters:
+            - BastionHostRequired
+      - Label:
           default: Elasticsearch
         Parameters:
           - ElasticsearchInstanceType
@@ -154,6 +158,8 @@ Metadata:
         default: JVM Heap Size Override
       JvmSupportOpts:
         default: Additional JVM options
+      BastionHostRequired:
+        default: Enable Bastion host usage
       KeyPairName:
         default: SSH Key Pair Name
       CustomDnsName:
@@ -178,12 +184,12 @@ Parameters:
     Type: String
   BitbucketLicenseKey:
     Default: ''
-    Description: (Optional) Provide a license key for Bitbucket Data Center if you have one. 
+    Description: (Optional) Provide a license key for Bitbucket Data Center if you have one.
     Type: String
   BitbucketAdminPassword:
-    AllowedPattern: '((?=^.{0,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*)|(^$)'    
+    AllowedPattern: '((?=^.{0,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*)|(^$)'
     ConstraintDescription: Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
-    Description: (Optional) Password for the Bitbucket administrator ('admin') account. 
+    Description: (Optional) Password for the Bitbucket administrator ('admin') account.
     MaxLength: 128
     NoEcho: true
     Type: String
@@ -529,9 +535,16 @@ Parameters:
     Default: ''
     Description: Pass in any additional JVM options to tune the Bitbucket instance
     Type: String
+  BastionHostRequired:
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: Whether to grant access to Crowd's EC2 instances through the ASI's Bastion host (if it exists). If 'true', remember to provide an EC2 Key Pair. If your ASI does not have a Bastion host, set this to 'false'.
+    Type: String
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
-    Description: The EC2 Key Pair to allow SSH access to the instances. If you don't provide one, the Atlassian Standard Infrastructure stack's key pair will be used.
+    Description: The EC2 Key Pair to allow SSH access to the instances.
     Type: String
     Default: ''
   CustomDnsName:
@@ -636,6 +649,9 @@ Conditions:
     !Equals [!Ref DBEngine, "Amazon Aurora PostgreSQL"]
   DBEnginePostgres:
     !Equals [!Ref DBEngine, "PostgreSQL"]
+  UseBastionHost: !And
+    - !Equals [!Ref BastionHostRequired, true]
+    - !Condition KeyProvided
 
 Mappings:
   AWSRegionArch2AMI:
@@ -940,7 +956,7 @@ Resources:
       KeyName: !If
         - KeyProvided
         - !Ref KeyPairName
-        - Fn::ImportValue: !Sub "${ExportPrefix}DefaultKey"
+        - Ref: AWS::NoValue
       IamInstanceProfile: !Ref BitbucketClusterNodeInstanceProfile
       ImageId:
         !FindInMap
@@ -1368,14 +1384,17 @@ Resources:
           FromPort: 7999
           ToPort: 7999
           CidrIp: !Ref CidrBlock
-        - IpProtocol: tcp
-          FromPort: 22
-          ToPort: 22
-          CidrIp:
-            !Sub
+        - !If
+          - UseBastionHost
+          - IpProtocol: tcp
+            FromPort: 22
+            ToPort: 22
+            CidrIp:
+              !Sub
               - "${BastionIp}/32"
               - BastionIp:
                   Fn::ImportValue: !Sub '${ExportPrefix}BastionPrivIp'
+          - Ref: AWS::NoValue
         - IpProtocol: tcp
           FromPort: 80
           ToPort: 80

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -544,7 +544,7 @@ Parameters:
     Type: String
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
-    Description: The EC2 Key Pair to allow SSH access to the instances.
+    Description: Public/private EC2 Key Pairs to allow you to securely access the Bastion host
     Type: String
     Default: ''
   CustomDnsName:

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -540,7 +540,7 @@ Parameters:
     AllowedValues:
       - "true"
       - "false"
-    Description: Whether to grant access to Crowd's EC2 instances through the ASI's Bastion host (if it exists). If 'true', remember to provide an EC2 Key Pair. If your ASI does not have a Bastion host, set this to 'false'.
+    Description: Whether to grant access to BitBucket EC2 instances through the ASI's Bastion host (if it exists). If 'true', remember to provide an EC2 Key Pair. If your ASI does not have a Bastion host, set this to 'false'.
     Type: String
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.


### PR DESCRIPTION
:warning:**DO NOT MERGE UNTIL DOCUMENTATION IS READY**:warning:

[Documentation ticket](https://bulldog.internal.atlassian.com/browse/DCD-994)


See the Crowd PR below for the basis of these changes including relevant discussion:

atlassian/quickstart-atlassian-crowd#26

**Passing on branch CI plan**
https://server-syd-bamboo.internal.atlassian.com/browse/DCD-AWSBITBUCKET44-DEPLOYAURORA-2