### PR TITLE
DCD-1001: Fix AnsibleRepoPinSHA resource deletion issue

### DIFF
--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -178,12 +178,12 @@ Parameters:
     Type: String
   BitbucketLicenseKey:
     Default: ''
-    Description: (Optional) Provide a license key for Bitbucket Data Center if you have one. 
+    Description: (Optional) Provide a license key for Bitbucket Data Center if you have one.
     Type: String
   BitbucketAdminPassword:
-    AllowedPattern: '((?=^.{0,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*)|(^$)'    
+    AllowedPattern: '((?=^.{0,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*)|(^$)'
     ConstraintDescription: Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
-    Description: (Optional) Password for the Bitbucket administrator ('admin') account. 
+    Description: (Optional) Password for the Bitbucket administrator ('admin') account.
     MaxLength: 128
     NoEcho: true
     Type: String
@@ -687,6 +687,7 @@ Resources:
           - Effect: Allow
             Action:
               - 'ssm:PutParameter'
+              - 'ssm:DeleteParameter'
             Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/pinned-ansible-sha"
       Roles:
         - !Ref BitbucketFileServerRole


### PR DESCRIPTION
Taskcat reaper was failing to delete the resource AnsibleRepoPinSHA.

This is no longer the case with this fix. Using the confluence stack below as a test case we can see that the resource is now being deleted when the reaper kicks in:

https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/stackinfo?filteringText=&filteringStatus=deleted&viewNested=false&hideStacks=false&stackId=arn%3Aaws%3Acloudformation%3Aus-east-1%3A887764444972%3Astack%2Ftcat-tag-confluence-2651c637%2Fc7652d30-942c-11ea-a8a3-12498e67507f