### PR TITLE
CHET-970: update the taskcat scenarios

### DIFF
--- a/ci/params/3nodes/quickstart-bitbucket-3nodes.json
+++ b/ci/params/3nodes/quickstart-bitbucket-3nodes.json
@@ -9,11 +9,11 @@
   },
   {
     "ParameterKey": "DBMasterUserPassword",
-    "ParameterValue": "f925dO1ry_"
+    "ParameterValue": "$[taskcat_genpass_8]S"
   },
   {
     "ParameterKey": "BitbucketAdminPassword",
-    "ParameterValue": "f925dO1ry_"
+    "ParameterValue": ""
   },
   {
     "ParameterKey": "CidrBlock",
@@ -25,7 +25,7 @@
   },
   {
     "ParameterKey": "DBPassword",
-    "ParameterValue": "f925dO1ry_"
+    "ParameterValue": "$[taskcat_genpass_8]S"
   },
   {
     "ParameterKey": "KeyPairName",

--- a/ci/params/aurora/quickstart-bitbucket-dc-aurora-params.json
+++ b/ci/params/aurora/quickstart-bitbucket-dc-aurora-params.json
@@ -5,15 +5,15 @@
   },
   {
     "ParameterKey": "DBMasterUserPassword",
-    "ParameterValue": "f925dO1ry_"
+    "ParameterValue": "$[taskcat_genpass_8]S"
   },
   {
     "ParameterKey": "BitbucketAdminPassword",
-    "ParameterValue": "f925dO1ry_"
+    "ParameterValue": ""
   },
   {
     "ParameterKey": "DBPassword",
-    "ParameterValue": "f925dO1ry_"
+    "ParameterValue": "$[taskcat_genpass_8]S"
   },
   {
     "ParameterKey": "QSS3BucketName",

--- a/ci/params/automated-setup/quickstart-bitbucket-automated-setup.json
+++ b/ci/params/automated-setup/quickstart-bitbucket-automated-setup.json
@@ -5,15 +5,19 @@
   },
   {
     "ParameterKey": "BitbucketVersion",
-    "ParameterValue": "6.8.1"
+    "ParameterValue": "6.10.1"
+  },
+  {
+    "ParameterKey": "BitbucketAdminPassword",
+    "ParameterValue": "$[taskcat_genpass_8]S"
+  },
+  {
+    "ParameterKey": "BitbucketLicenseKey",
+    "ParameterValue": "AAABow0ODAoPeNp1kUlv2zAQRu/8FQP0ZoCyvCRpDQhoI7FpilgybLlAtwNFTyw2MimQI7f+96VttUmXHHjhLHjfmxdl3cFcHmA0hfhyNpnM4gnczEsYx+OY5d2uQlfcrz06n/ARS60hqSiXO0xk5ewD+teSGum9liZSdsc8SV9Hd1qh8VgeWjz1ZuKDuCsWYvlv/Ult0TlVS4+ZJEyOADy+4KMpe35bXxE/Wu0Op7HF+N0vSjGXunkGc4Vuj+42S67FleDT7NOYXxbvr/jN5NXLnjGskykaQpeQ65Ctusorp1vS1px/BoNBXpT8bbHki2WRrdPytsj5eiVCIUkdBp4NVAegGqEnBWGU3aCD1tlvqAg+10Ttl9lwuLXRH4jD5jzB8TzxNYLMgrEEG+3J6aojDJu1B7KgOk92F44UsRA6MBtp1FMtweaot3lOF/zoPf7OkS7Fm1Jk/Prjkf3/zvoIQdraPBj73bCVyJPw+EUcs8JtpdFenvSU6EmbLTtJCB9/XzTDR5XHXujDwr0Nappuqw1scI+NbUMoJvay6eSj+J8JvettMCwCFGeLfqXRBKGBQ/HZf6nfl1da0Qf8AhQQu6OUrfk71nQqUW0h3TeNFVyuGg==X02k8"
   },
   {
     "ParameterKey": "DBMasterUserPassword",
     "ParameterValue": "$[taskcat_genpass_8]S"
-  },
-  {
-    "ParameterKey": "BitbucketAdminPassword",
-    "ParameterValue": ""
   },
   {
     "ParameterKey": "CidrBlock",

--- a/ci/params/automated-setup/taskcat.yml
+++ b/ci/params/automated-setup/taskcat.yml
@@ -1,0 +1,26 @@
+---
+global:
+  qsname: quickstart-atlassian-bitbucket
+  owner: quickstart-eng@amazon.com
+  marketplace-ami: false
+  reporting: true
+  regions:
+    - ap-northeast-1
+    - ap-northeast-2
+    - ap-south-1
+    - ap-southeast-1
+    - ap-southeast-2
+    - eu-central-1
+    - eu-west-1
+    - sa-east-1
+    - us-east-1
+    - us-east-2
+    - us-west-1
+    - us-west-2
+
+tests:
+  BB-5:
+    template_file: quickstart-bitbucket-dc.template.yaml
+    parameter_input: params/automated-setup/quickstart-bitbucket-automated-setup.json
+    regions:
+     - us-east-1

--- a/ci/params/ssl-and-dns/quickstart-bitbucket-ci-params.json
+++ b/ci/params/ssl-and-dns/quickstart-bitbucket-ci-params.json
@@ -5,11 +5,11 @@
     },
     {
         "ParameterKey": "DBMasterUserPassword",
-        "ParameterValue": "f925dO1ry_"
+        "ParameterValue": "$[taskcat_genpass_8]S"
     },
     {
         "ParameterKey": "BitbucketAdminPassword",
-        "ParameterValue": "f925dO1ry_"
+        "ParameterValue": ""
     },
     {
         "ParameterKey": "DBMultiAZ",
@@ -17,7 +17,7 @@
     },
     {
         "ParameterKey": "DBPassword",
-        "ParameterValue": "f925dO1ry_"
+        "ParameterValue": "$[taskcat_genpass_8]S"
     },
     {
         "ParameterKey": "DBStorage",

--- a/ci/quickstart-bitbucket-master.json
+++ b/ci/quickstart-bitbucket-master.json
@@ -5,15 +5,15 @@
     },
     {
         "ParameterKey": "BitbucketVersion",
-        "ParameterValue": "6.6.0"
+        "ParameterValue": "6.10.0"
     },
     {
         "ParameterKey": "DBMasterUserPassword",
-        "ParameterValue": "f925dO1ry_"
+        "ParameterValue": "$[taskcat_genpass_8]S"
     },
     {
         "ParameterKey": "BitbucketAdminPassword",
-        "ParameterValue": "f925dO1ry_"
+        "ParameterValue": ""
     },
     {
         "ParameterKey": "AccessCIDR",
@@ -33,7 +33,7 @@
     },
     {
         "ParameterKey": "DBPassword",
-        "ParameterValue": "f925dO1ry_"
+        "ParameterValue": "$[taskcat_genpass_8]S"
     },
     {
         "ParameterKey": "KeyPairName",


### PR DESCRIPTION
* add automated setup scenario to make testing the DCD-970 change easier
* remove unnecessary `BitbucketAdminPassword` value
* change our hardcoded passwords to autogenerated ones