### PR TITLE
GitHub action for linting CFN templates

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -5,3 +5,9 @@ ignore_checks:
     # The check cannot handle this situation:
     # Iops: !If [IsHomeProvisionedIops, !Ref HomeIops, !Ref "AWS::NoValue"]
     # VolumeType: !If [IsHomeProvisionedIops, io1, gp2]
+  - W4002  
+    # W4002: As the resource "metadata" section contains reference to a "NoEcho" parameter DBMasterUserPassword, CloudFormation will display the parameter value in plaintext
+  - E3012
+    # E3012: Property Resources/EFSCname/Properties/TTL should be of type Long
+  - E1001
+    # E1001: Top level template section tests is not valid

--- a/.github/workflows/cfn-lint.yml
+++ b/.github/workflows/cfn-lint.yml
@@ -1,0 +1,17 @@
+name: Lint CloudFormation Templates
+
+on: [push]
+
+jobs:
+  cloudformation-linter:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: cfn-lint
+        uses: scottbrenner/cfn-lint-action@master
+        with:
+          args: "templates/*.yaml"

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -703,8 +703,7 @@ Resources:
           - Effect: Allow
             Action:
               - 'ssm:PutParameter'
-            Resource: !Sub
-              - arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/pinned-ansible-sha
+            Resource: !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/pinned-ansible-sha"
       Roles:
         - !Ref BitbucketFileServerRole
         - !Ref BitbucketClusterNodeRole

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -704,8 +704,7 @@ Resources:
             Action:
               - 'ssm:PutParameter'
             Resource: !Sub
-              - arn:${ArnPartition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/pinned-ansible-sha
-              - ArnPartition: !If ["GovCloudCondition", "aws-us-gov", "aws"]
+              - arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/pinned-ansible-sha
       Roles:
         - !Ref BitbucketFileServerRole
         - !Ref BitbucketClusterNodeRole


### PR DESCRIPTION
Lint CFN templates before merging. Were using the following GitHub action for this:

https://github.com/marketplace/actions/cfn-lint-action

which consumes the current .cfnlintrc file.

This action will also make commentary directly against the PR files themselves:

![image](https://user-images.githubusercontent.com/409063/88257126-6d8ef180-cd00-11ea-8e78-94fd82cefb51.png)
