### PR TITLE
DCD-1052: Add ClusterNodeVolumeSize parameter to define root size

### DIFF
--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -15,6 +15,7 @@ Metadata:
           - ClusterNodeInstanceType
           - ClusterNodeMax
           - ClusterNodeMin
+          - ClusterNodeVolumeSize
           - DeploymentAutomationRepository
           - DeploymentAutomationBranch
           - DeploymentAutomationPlaybook
@@ -107,6 +108,8 @@ Metadata:
         default: Minimum number of cluster nodes
       ClusterNodeInstanceType:
         default: Bitbucket cluster node instance type
+      ClusterNodeVolumeSize:
+        default: Cluster node instance volume size
       CreateBucket:
         default: Create S3 bucket for Elasticsearch snapshots
       DBEngine:
@@ -334,6 +337,10 @@ Parameters:
   ClusterNodeMin:
     Default: 1
     Description: Set to 1 for new deployment. Can be updated post launch.
+    Type: Number
+  ClusterNodeVolumeSize:
+    Default: 50
+    Description: Size of cluster node root volume in Gb
     Type: Number
   CreateBucket:
     Default: "true"
@@ -682,6 +689,7 @@ Resources:
         ClusterNodeInstanceType: !Ref 'ClusterNodeInstanceType'
         ClusterNodeMax: !Ref 'ClusterNodeMax'
         ClusterNodeMin: !Ref 'ClusterNodeMin'
+        ClusterNodeVolumeSize: !Ref 'ClusterNodeVolumeSize'
         CreateBucket: !Ref 'CreateBucket'
         CustomDnsName: !Ref 'CustomDnsName'
         DBInstanceClass: !Ref 'DBInstanceClass'

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -15,6 +15,7 @@ Metadata:
           - ClusterNodeInstanceType
           - ClusterNodeMax
           - ClusterNodeMin
+          - ClusterNodeVolumeSize
           - DeploymentAutomationRepository
           - DeploymentAutomationBranch
           - DeploymentAutomationPlaybook
@@ -96,6 +97,8 @@ Metadata:
         default: Minimum number of cluster nodes
       ClusterNodeInstanceType:
         default: Bitbucket cluster node instance type
+      ClusterNodeVolumeSize:
+        default: Cluster node instance volume size
       CreateBucket:
         default: Create S3 bucket for Elasticsearch snapshots
       DBEngine:
@@ -307,6 +310,10 @@ Parameters:
   ClusterNodeMin:
     Default: 1
     Description: Set to 1 for new deployment. Can be updated post launch.
+    Type: Number
+  ClusterNodeVolumeSize:
+    Default: 50
+    Description: Size of cluster node root volume in Gb
     Type: Number
   CreateBucket:
     Default: "true"
@@ -1167,6 +1174,9 @@ Resources:
 
     Properties:
       BlockDeviceMappings:
+        - DeviceName: /dev/xvda
+          Ebs:
+            VolumeSize: !Ref ClusterNodeVolumeSize
         - DeviceName: /dev/xvdf
           Ebs:
             DeleteOnTermination: !Ref HomeDeleteOnTermination


### PR DESCRIPTION
Introduce `ClusterNodeVolumeSize` parameter for https://jira.atlassian.com/browse/SCALE-23

I've bumped the size from default 8GB to 50GB to give it some room (although Bitbucket doesn't need so much local space as Jira and Confluence indexes).