### PR TITLE
DCD-1037: Update LTS to 6.10.5

### DIFF
--- a/ci/params/automated-setup/quickstart-bitbucket-automated-setup.json
+++ b/ci/params/automated-setup/quickstart-bitbucket-automated-setup.json
@@ -5,7 +5,7 @@
   },
   {
     "ParameterKey": "BitbucketVersion",
-    "ParameterValue": "6.10.1"
+    "ParameterValue": "6.10.5"
   },
   {
     "ParameterKey": "BitbucketAdminPassword",

--- a/ci/quickstart-bitbucket-master.json
+++ b/ci/quickstart-bitbucket-master.json
@@ -4,10 +4,6 @@
         "ParameterValue": "$[taskcat_genaz_2]"
     },
     {
-        "ParameterKey": "BitbucketVersion",
-        "ParameterValue": "6.10.0"
-    },
-    {
         "ParameterKey": "DBMasterUserPassword",
         "ParameterValue": "$[taskcat_genpass_8S]"
     },

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -199,7 +199,7 @@ Parameters:
     Description: A comma-separated list of bitbucket properties in the form 'key1=value1, key2=value2, ...' Find documentation at https://confluence.atlassian.com/x/m5ZKLg
     Type: CommaDelimitedList
   BitbucketVersion:
-    Default: "6.10.0"
+    Default: "6.10.5"
     AllowedPattern: '([^1234]\.\d+\.\d+(-?.*))'
     ConstraintDescription: 'Must be a valid Bitbucket version number. For example: 5.0.0 or higher'
     Description: 'Version of Bitbucket to install. Please use version 5.0.0 or higher. Find valid versions at http://go.atlassian.com/bbs-releases'

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -180,7 +180,7 @@ Parameters:
     Description: A comma-separated list of bitbucket properties in the form 'key1=value1, key2=value2, ...' Find documentation at https://confluence.atlassian.com/x/m5ZKLg
     Type: CommaDelimitedList
   BitbucketVersion:
-    Default: "6.10.0"
+    Default: "6.10.5"
     AllowedPattern: '([^1234]\.\d+\.\d+(-?.*))'
     ConstraintDescription: 'Must be a valid Bitbucket version number. For example: 5.0.0 or higher'
     Description: 'Version of Bitbucket to install. Please use version 5.0.0 or higher. Find valid versions at http://go.atlassian.com/bbs-releases'


### PR DESCRIPTION
* This will retarget develop after DCD-1052 is merged

I took the liberty to update other products (even though the ticket was referring just to Confluence)