### PR TITLE
DCD-1035: Add DBEngineVersion parameter

### DIFF
--- a/ci/params/dbVersions/quickstart-bitbucket-aurora-10.json
+++ b/ci/params/dbVersions/quickstart-bitbucket-aurora-10.json
@@ -16,6 +16,18 @@
     "ParameterValue": "0.0.0.0/0"
   },
   {
+    "ParameterKey": "DBEngineVersion",
+    "ParameterValue": "10"
+  },
+  {
+    "ParameterKey": "DBInstanceClass",
+    "ParameterValue": "db.r5.large"
+  },
+  {
+    "ParameterKey": "DBEngine",
+    "ParameterValue": "Amazon Aurora PostgreSQL"
+  },
+  {
     "ParameterKey": "DBIops",
     "ParameterValue": "1000"
   },
@@ -30,10 +42,6 @@
   {
     "ParameterKey": "ClusterNodeInstanceType",
     "ParameterValue": "t3.medium"
-  },
-  {
-    "ParameterKey": "DBInstanceClass",
-    "ParameterValue": "db.t3.medium"
   },
   {
     "ParameterKey": "QSS3BucketName",

--- a/ci/params/dbVersions/quickstart-bitbucket-aurora-11.json
+++ b/ci/params/dbVersions/quickstart-bitbucket-aurora-11.json
@@ -16,6 +16,18 @@
     "ParameterValue": "0.0.0.0/0"
   },
   {
+    "ParameterKey": "DBEngineVersion",
+    "ParameterValue": "11"
+  },
+  {
+    "ParameterKey": "DBInstanceClass",
+    "ParameterValue": "db.r5.large"
+  },
+  {
+    "ParameterKey": "DBEngine",
+    "ParameterValue": "Amazon Aurora PostgreSQL"
+  },
+  {
     "ParameterKey": "DBIops",
     "ParameterValue": "1000"
   },
@@ -30,10 +42,6 @@
   {
     "ParameterKey": "ClusterNodeInstanceType",
     "ParameterValue": "t3.medium"
-  },
-  {
-    "ParameterKey": "DBInstanceClass",
-    "ParameterValue": "db.t3.medium"
   },
   {
     "ParameterKey": "QSS3BucketName",

--- a/ci/params/dbVersions/quickstart-bitbucket-postgres-10.json
+++ b/ci/params/dbVersions/quickstart-bitbucket-postgres-10.json
@@ -16,6 +16,14 @@
     "ParameterValue": "0.0.0.0/0"
   },
   {
+    "ParameterKey": "DBEngineVersion",
+    "ParameterValue": "10"
+  },
+  {
+    "ParameterKey": "DBEngine",
+    "ParameterValue": "PostgreSQL"
+  },
+  {
     "ParameterKey": "DBIops",
     "ParameterValue": "1000"
   },

--- a/ci/params/dbVersions/quickstart-bitbucket-postgres-11.json
+++ b/ci/params/dbVersions/quickstart-bitbucket-postgres-11.json
@@ -16,6 +16,14 @@
     "ParameterValue": "0.0.0.0/0"
   },
   {
+    "ParameterKey": "DBEngineVersion",
+    "ParameterValue": "11"
+  },
+  {
+    "ParameterKey": "DBEngine",
+    "ParameterValue": "PostgreSQL"
+  },
+  {
     "ParameterKey": "DBIops",
     "ParameterValue": "1000"
   },

--- a/ci/params/dbVersions/quickstart-bitbucket-postgres-12.json
+++ b/ci/params/dbVersions/quickstart-bitbucket-postgres-12.json
@@ -16,6 +16,14 @@
     "ParameterValue": "0.0.0.0/0"
   },
   {
+    "ParameterKey": "DBEngineVersion",
+    "ParameterValue": "10"
+  },
+  {
+    "ParameterKey": "DBEngine",
+    "ParameterValue": "PostgreSQL"
+  },
+  {
     "ParameterKey": "DBIops",
     "ParameterValue": "1000"
   },

--- a/ci/params/dbVersions/taskcat.yml
+++ b/ci/params/dbVersions/taskcat.yml
@@ -1,0 +1,50 @@
+---
+global:
+  qsname: quickstart-atlassian-bitbucket
+  owner: quickstart-eng@amazon.com
+  marketplace-ami: false
+  reporting: true
+  regions:
+    - ap-northeast-1
+    - ap-northeast-2
+    - ap-south-1
+    - ap-southeast-1
+    - ap-southeast-2
+    - eu-central-1
+    - eu-west-1
+    - sa-east-1
+    - us-east-1
+    - us-east-2
+    - us-west-1
+    - us-west-2
+
+tests:
+  BB-aurora-10:
+    template_file: quickstart-bitbucket-dc.template.yaml
+    parameter_input: params/dbVersions/quickstart-bitbucket-aurora-10.json
+    regions:
+     - us-east-1
+
+  BB-aurora-11:
+    template_file: quickstart-bitbucket-dc.template.yaml
+    parameter_input: params/dbVersions/quickstart-bitbucket-aurora-11.json
+    regions:
+     - us-east-1
+    
+  BB-postgres-10:
+    template_file: quickstart-bitbucket-dc.template.yaml
+    parameter_input: params/dbVersions/quickstart-bitbucket-postgres-10.json
+    regions:
+     - us-east-1
+
+  BB-postgres-11:
+    template_file: quickstart-bitbucket-dc.template.yaml
+    parameter_input: params/dbVersions/quickstart-bitbucket-postgres-11.json
+    regions:
+     - us-east-1
+  
+  BB-postgres-12:
+    template_file: quickstart-bitbucket-dc.template.yaml
+    parameter_input: params/dbVersions/quickstart-bitbucket-postgres-12.json
+    regions:
+     - us-east-1

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -32,6 +32,7 @@ Metadata:
           default: Database
         Parameters:
           - DBEngine
+          - DBEngineVersion
           - DBInstanceClass
           - DBIops
           - DBMasterUserPassword
@@ -114,6 +115,8 @@ Metadata:
         default: Create S3 bucket for Elasticsearch snapshots
       DBEngine:
         default: The database engine to deploy with
+      DBEngineVersion:
+        default: The database engine version to use
       DBInstanceClass:
         default: Database instance class
       DBIops:
@@ -381,6 +384,14 @@ Parameters:
       - 'Amazon Aurora PostgreSQL'
       - 'PostgreSQL'
     ConstraintDescription: Must be 'Amazon Aurora PostgreSQL' or 'PostgreSQL'.
+    Type: String
+  DBEngineVersion:
+    Default: 11
+    AllowedValues:
+      - 10
+      - 11
+      - 12
+    Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Jira version you're installing supports the database engine selected."
     Type: String
   DBInstanceClass:
     Default: db.m4.large
@@ -698,6 +709,7 @@ Resources:
         DBMultiAZ: !Ref 'DBMultiAZ'
         DBPassword: !Ref 'DBPassword'
         DBEngine: !Ref 'DBEngine'
+        DBEngineVersion: !Ref 'DBEngineVersion'
         DBMaster: !Ref 'DBMaster'
         DBSnapshotId: !Ref 'DBSnapshotId'
         DBStorage: !Ref 'DBStorage'

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -32,6 +32,7 @@ Metadata:
           default: Database
         Parameters:
           - DBEngine
+          - DBEngineVersion
           - DBInstanceClass
           - DBIops
           - DBMasterUserPassword
@@ -103,6 +104,8 @@ Metadata:
         default: Create S3 bucket for Elasticsearch snapshots
       DBEngine:
         default: The database engine to deploy with
+      DBEngineVersion:
+        default: The database engine version to use
       DBInstanceClass:
         default: Database instance class
       DBIops:
@@ -354,6 +357,14 @@ Parameters:
       - 'Amazon Aurora PostgreSQL'
       - 'PostgreSQL'
     ConstraintDescription: Must be 'Amazon Aurora PostgreSQL' or 'PostgreSQL'.
+    Type: String
+  DBEngineVersion:
+    Default: 11
+    AllowedValues:
+      - 10
+      - 11
+      - 12
+    Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Jira version you're installing supports the database engine selected."
     Type: String
   DBInstanceClass:
     Default: db.m4.large
@@ -834,10 +845,10 @@ Resources:
           PropagateAtLaunch: true
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 1f4a225e65963588f7fd184bc93a5a04b4367c3e"
+          Value: "COMMIT: 89cd62a4be68dba385cf6c93b7a3d75b842002dd"
           PropagateAtLaunch: true
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-07-30T01:34:17Z"
+          Value: "TIMESTAMP: 2020-08-05T11:26:44Z"
           PropagateAtLaunch: true
   ClusterNodeLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
@@ -1285,13 +1296,13 @@ Resources:
       DBSnapshotIdentifier: !If [RestoreFromRDSSnapshot, !Ref DBSnapshotId, !Ref "AWS::NoValue"]
       DBSubnetGroupName: !Ref DBSubnetGroup
       Engine: postgres
-      EngineVersion: '10'
+      EngineVersion: !Ref DBEngineVersion
       Iops: !If [DBProvisionedIops, !Ref DBIops, !Ref "AWS::NoValue"]
       MasterUsername: !If ["SetDBMasterUserAndPassword", postgres, !Ref "AWS::NoValue"]
       MasterUserPassword: !If ["SetDBMasterUserAndPassword", !Ref DBMasterUserPassword, !Ref "AWS::NoValue"]
       MultiAZ: !If [StandbyMode, !Ref "AWS::NoValue", !Ref DBMultiAZ]
-      StorageType: !If [DBProvisionedIops, io1, gp2]
       SourceDBInstanceIdentifier: !If [StandbyMode, !Ref DBMaster, !Ref "AWS::NoValue"]
+      StorageType: !If [DBProvisionedIops, io1, gp2]
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName} Bitbucket PostgreSQL Database"
@@ -1313,14 +1324,15 @@ Resources:
         - QSS3Region: !If ["GovCloudCondition", "s3-us-gov-west-1", "s3"]
       Parameters:
         DatabaseImplementation: !Ref DBEngine
-        DBSecurityGroup: !Ref SecurityGroup
+        DBAllocatedStorage: !Ref DBStorage
         DBAutoMinorVersionUpgrade: "true"
         DBBackupRetentionPeriod: "1"
+        DBEngineVersion: !Ref DBEngineVersion
         DBInstanceClass: !Ref DBInstanceClass
         DBIops: !Ref DBIops
         DBMasterUserPassword: !Ref DBMasterUserPassword
         DBMultiAZ: !Ref DBMultiAZ
-        DBAllocatedStorage: !Ref DBStorage
+        DBSecurityGroup: !Ref SecurityGroup
         DBStorageType: !Ref DBStorageType
         ExportPrefix: !Ref ExportPrefix
         QSS3BucketName: !Ref QSS3BucketName


### PR DESCRIPTION
* Added support for DBEngineVersion
* Bitbucket had version 10 by default, so we are supporting 10, 11, 12 for Postgres
* There is no Aurora version 11, TBD

- [ ] Handle Aurora 12

Tested different combinations.
<img width="2532" alt="image" src="https://user-images.githubusercontent.com/416238/89407980-0a22ac00-d763-11ea-8e38-6c07f301fbf4.png">
