### PR TITLE
DCD-953: Remove unused ES snapshot restore parameter

### DIFF
--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -73,7 +73,6 @@ Metadata:
           - DBMaster
           - DBSnapshotId
           - ESBucketName
-          - ESSnapshotId
           - HomeVolumeSnapshotId
           - HomeDeleteOnTermination
           - BitbucketLicenseKey
@@ -153,8 +152,6 @@ Metadata:
         default: Elasticsearch disk space per node (GB)
       ESBucketName:
         default: Elasticsearch snapshot S3 bucket name
-      ESSnapshotId:
-        default: Elasticsearch snapshot ID to restore
       ExportPrefix:
         default: ASI Exported Prefix
       FileServerInstanceType:
@@ -508,12 +505,6 @@ Parameters:
     ConstraintDescription: Must contain only lowercase letters, numbers and hyphens (-).
     Description: Name of a new, or existing, S3 bucket configured for Elasticsearch snapshots.
     Type: String
-  ESSnapshotId:
-    Default: ''
-    AllowedPattern: '[a-z0-9-]*'
-    ConstraintDescription: Must contain only lowercase letters, numbers and hyphens (-).
-    Description: Must be a valid snapshot ID for a snapshot in the configured S3 snapshot repository, must be used in conjunction with ESBucketName set to a correctly configured bucket.
-    Type: String
   ExportPrefix:
     Default: 'ATL-'
     Description:
@@ -723,7 +714,6 @@ Resources:
         ElasticsearchInstanceType: !Ref 'ElasticsearchInstanceType'
         ElasticsearchNodeVolumeSize: !Ref 'ElasticsearchNodeVolumeSize'
         ESBucketName: !Ref 'ESBucketName'
-        ESSnapshotId: !Ref 'ESSnapshotId'
         FileServerInstanceType: !Ref 'FileServerInstanceType'
         HomeDeleteOnTermination: !Ref 'HomeDeleteOnTermination'
         HomeIops: !Ref 'HomeIops'

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -635,8 +635,8 @@ Conditions:
     !Equals ['6', !Select [1, !Split ['.', !Ref BitbucketVersion]]]
   ShouldUseES23:
     !And [Condition: IsVersion5X, !Or [Condition: IsVersionX0, Condition: IsVersionX1, Condition: IsVersionX2, Condition: IsVersionX3, Condition: IsVersionX4, Condition: IsVersionX5, Condition: IsVersionX6]]
-  RestoreRDSOrStandby:
-    !Or [Condition: RestoreFromRDSSnapshot, Condition: StandbyMode]
+  CreateESBucket:
+    !Equals [!Ref CreateBucket, 'true']
   SetDBMasterUserAndPassword:
     !And [!Not [!Equals [!Ref DBMasterUserPassword, '']], Condition: NotStandbyMode]
   UsePublicIp:

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -1044,7 +1044,7 @@ Resources:
           Value: !Ref "AWS::StackId"
   ElasticsearchBucket:
     Type: AWS::S3::Bucket
-    Condition: CreateBucket
+    Condition: CreateESBucket
     Properties:
       BucketName: !Ref ESBucketName
       Tags:

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -635,6 +635,8 @@ Conditions:
     !Equals ['6', !Select [1, !Split ['.', !Ref BitbucketVersion]]]
   ShouldUseES23:
     !And [Condition: IsVersion5X, !Or [Condition: IsVersionX0, Condition: IsVersionX1, Condition: IsVersionX2, Condition: IsVersionX3, Condition: IsVersionX4, Condition: IsVersionX5, Condition: IsVersionX6]]
+  RestoreRDSOrStandby:
+    !Or [Condition: RestoreFromRDSSnapshot, Condition: StandbyMode]
   CreateESBucket:
     !Equals [!Ref CreateBucket, 'true']
   SetDBMasterUserAndPassword:

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -638,7 +638,9 @@ Conditions:
   RestoreRDSOrStandby:
     !Or [Condition: RestoreFromRDSSnapshot, Condition: StandbyMode]
   CreateESBucket:
-    !Equals [!Ref CreateBucket, 'true']
+    !And
+    - !Equals [!Ref CreateBucket, 'true']
+    - Condition: ESBucketNameSet
   SetDBMasterUserAndPassword:
     !And [!Not [!Equals [!Ref DBMasterUserPassword, '']], Condition: NotStandbyMode]
   UsePublicIp:

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -67,7 +67,6 @@ Metadata:
           - DBMaster
           - DBSnapshotId
           - ESBucketName
-          - ESSnapshotId
           - HomeVolumeSnapshotId
           - HomeDeleteOnTermination
           - BitbucketLicenseKey
@@ -142,8 +141,6 @@ Metadata:
         default: Elasticsearch disk space per node (GB)
       ESBucketName:
         default: Elasticsearch snapshot S3 bucket name
-      ESSnapshotId:
-        default: Elasticsearch snapshot ID to restore
       ExportPrefix:
         default: ASI identifier
       FileServerInstanceType:
@@ -481,12 +478,6 @@ Parameters:
     ConstraintDescription: Must contain only lowercase letters, numbers and hyphens (-).
     Description: Name of a new, or existing, S3 bucket configured for Elasticsearch snapshots.
     Type: String
-  ESSnapshotId:
-    Default: ''
-    AllowedPattern: '[a-z0-9-]*'
-    ConstraintDescription: Must contain only lowercase letters, numbers and hyphens (-).
-    Description: Must be a valid snapshot ID for a snapshot in the configured S3 snapshot repository, must be used in conjunction with ESBucketName set to a correctly configured bucket.
-    Type: String
   ExportPrefix:
     Default: 'ATL-'
     Description:
@@ -612,16 +603,6 @@ Conditions:
     !Not [!Equals [!Ref HomeVolumeSnapshotId, '']]
   RestoreFromRDSSnapshot:
     !Not [!Equals [!Ref DBSnapshotId, '']]
-  RestoreFromESSnapshot:
-    !And
-    - !Not [!Equals [!Ref ESSnapshotId, '']]
-    - Condition: ESBucketNameSet
-  CreateESBucket:
-    !And
-    - !Equals [!Ref CreateBucket, 'true']
-    - !And
-      - !Not [Condition: RestoreFromESSnapshot]
-      - Condition: ESBucketNameSet
   ESBucketNameSet:
     !Not [!Equals [!Ref ESBucketName, '']]
   StandbyMode:
@@ -1063,7 +1044,7 @@ Resources:
           Value: !Ref "AWS::StackId"
   ElasticsearchBucket:
     Type: AWS::S3::Bucket
-    Condition: CreateESBucket
+    Condition: CreateBucket
     Properties:
       BucketName: !Ref ESBucketName
       Tags:


### PR DESCRIPTION
DCD-953: Remove unused ES snapshot restore parameter; will need to re-added if we implement this in the Ansible playbooks.