### PR TITLE
DCD-1077: Put JvmSupportOpts in quotation mark to avoid raising error…

### DIFF
--- a/ci/params/jvm-support-opts/quickstart-bitbucket-jvm-support-opts.json
+++ b/ci/params/jvm-support-opts/quickstart-bitbucket-jvm-support-opts.json
@@ -1,0 +1,50 @@
+[
+  {
+    "ParameterKey": "DBMultiAZ",
+    "ParameterValue": "false"
+  },
+  {
+    "ParameterKey": "DBMasterUserPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
+    "ParameterKey": "BitbucketAdminPassword",
+    "ParameterValue": ""
+  },
+  {
+    "ParameterKey": "CidrBlock",
+    "ParameterValue": "0.0.0.0/0"
+  },
+  {
+    "ParameterKey": "DBIops",
+    "ParameterValue": "1000"
+  },
+  {
+    "ParameterKey": "DBPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
+    "ParameterKey": "KeyPairName",
+    "ParameterValue": "replaced-by-taskcat-override-file"
+  },
+  {
+    "ParameterKey": "ClusterNodeInstanceType",
+    "ParameterValue": "t3.medium"
+  },
+  {
+    "ParameterKey": "DBInstanceClass",
+    "ParameterValue": "db.t3.medium"
+  },
+  {
+    "ParameterKey": "QSS3BucketName",
+    "ParameterValue": "$[taskcat_autobucket]"
+  },
+  {
+    "ParameterKey": "QSS3KeyPrefix",
+    "ParameterValue": "quickstart-atlassian-bitbucket/"
+  },
+  {
+    "ParameterKey": "JvmSupportOpts",
+    "ParameterValue": "-Dhttp.proxyHost=10.15.112.40 -Dhttp.proxyPort=3128 -Dhttps.proxyHost=10.15.112.40 -Dhttps.proxyPort=3128 -Dhttp.nonProxyHosts=localhost|169.254.169.254"
+  }
+]

--- a/ci/params/jvm-support-opts/taskcat.yml
+++ b/ci/params/jvm-support-opts/taskcat.yml
@@ -1,0 +1,26 @@
+---
+global:
+  qsname: quickstart-atlassian-bitbucket
+  owner: quickstart-eng@amazon.com
+  marketplace-ami: false
+  reporting: true
+  regions:
+    - ap-northeast-1
+    - ap-northeast-2
+    - ap-south-1
+    - ap-southeast-1
+    - ap-southeast-2
+    - eu-central-1
+    - eu-west-1
+    - sa-east-1
+    - us-east-1
+    - us-east-2
+    - us-west-1
+    - us-west-2
+
+tests:
+  BB-5:
+    template_file: quickstart-bitbucket-dc.template.yaml
+    parameter_input: params/jvm-support-opts/quickstart-bitbucket-jvm-support-opts.json
+    regions:
+     - us-east-1

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -865,7 +865,7 @@ Resources:
                   - !Sub ["ATL_DEPLOYMENT_REPOSITORY_CUSTOM_PARAMS='${DeployRepositoryCustomParams}'", DeployRepositoryCustomParams: !Ref "DeploymentAutomationCustomParams"]
                   - ""
                   - !Sub ["ATL_JVM_HEAP=${JvmHeapOverride}", JvmHeapOverride: !Ref "JvmHeapOverride"]
-                  - !Sub ["ATL_JVM_OPTS=${JvmSupportOpts}", JvmSupportOpts: !Ref "JvmSupportOpts"]
+                  - !Sub ["ATL_JVM_OPTS='${JvmSupportOpts}'", JvmSupportOpts: !Ref "JvmSupportOpts"]
                   - ""
                   - !Sub ["ATL_AWS_REGION=${Region}", Region: !Ref "AWS::Region"]
                   - !Sub ["ATL_AWS_STACK_NAME=${StackName}", StackName: !Ref "AWS::StackName"]


### PR DESCRIPTION
If there are more than one option in atl_jvm_opts, naturally options will separate by space. JVM_SUPPORT_RECOMMENDED_ARGS will be assigned by the atl_jvm_opts value and in this case ansible will consider the first token as the value and assume the second term is next command which ended to an error (Invalid command!)
To fix this, we need to wrap all options of ATL_JVM_OPTS in a quotation mark. 