### PR TITLE
Scale 23 make bitbucket node volume configurable

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "submodules/quickstart-atlassian-services"]
 	path = submodules/quickstart-atlassian-services
 	url = https://github.com/aws-quickstart/quickstart-atlassian-services.git
-	branch = master
+	branch = main

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -313,7 +313,7 @@ Parameters:
     Type: Number
   ClusterNodeVolumeSize:
     Default: 50
-    Description: Size of cluster node root volume in Gb
+    Description: Size of Bitbucket web server cluster node volume in Gb
     Type: Number
   CreateBucket:
     Default: "true"
@@ -956,6 +956,10 @@ Resources:
 
     Properties:
       AssociatePublicIpAddress: false
+      BlockDeviceMappings:
+        - DeviceName: /dev/xvda
+          Ebs:
+            VolumeSize: !Ref ClusterNodeVolumeSize
       KeyName: !If
         - KeyProvided
         - !Ref KeyPairName
@@ -1170,9 +1174,6 @@ Resources:
 
     Properties:
       BlockDeviceMappings:
-        - DeviceName: /dev/xvda
-          Ebs:
-            VolumeSize: !Ref ClusterNodeVolumeSize
         - DeviceName: /dev/xvdf
           Ebs:
             DeleteOnTermination: !Ref HomeDeleteOnTermination


### PR DESCRIPTION
The parameter we created to modify the cluster node volume was used on the file server EC2 instance instead of the Bitbucket webapp nodes. I've moved it around and verified the space on the device

![image](https://user-images.githubusercontent.com/21027663/93733080-43ca4c00-fc17-11ea-87cc-d2426bd1e0ee.png)


