### PR TITLE
Dcd 1156 elastic search version

### DIFF
--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -617,22 +617,6 @@ Conditions:
     !Not [!Equals [!Ref KeyPairName, '']]
   IsHomeProvisionedIops:
     !Equals [!Ref HomeVolumeType, Provisioned IOPS]
-  IsVersion5X:
-    !Equals ['5', !Select [0, !Split ['.', !Ref BitbucketVersion]]]
-  IsVersionX0:
-    !Equals ['0', !Select [1, !Split ['.', !Ref BitbucketVersion]]]
-  IsVersionX1:
-    !Equals ['1', !Select [1, !Split ['.', !Ref BitbucketVersion]]]
-  IsVersionX2:
-    !Equals ['2', !Select [1, !Split ['.', !Ref BitbucketVersion]]]
-  IsVersionX3:
-    !Equals ['3', !Select [1, !Split ['.', !Ref BitbucketVersion]]]
-  IsVersionX4:
-    !Equals ['4', !Select [1, !Split ['.', !Ref BitbucketVersion]]]
-  IsVersionX5:
-    !Equals ['5', !Select [1, !Split ['.', !Ref BitbucketVersion]]]
-  IsVersionX6:
-    !Equals ['6', !Select [1, !Split ['.', !Ref BitbucketVersion]]]
   RestoreRDSOrStandby:
     !Or [Condition: RestoreFromRDSSnapshot, Condition: StandbyMode]
   CreateESBucket:

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -633,8 +633,6 @@ Conditions:
     !Equals ['5', !Select [1, !Split ['.', !Ref BitbucketVersion]]]
   IsVersionX6:
     !Equals ['6', !Select [1, !Split ['.', !Ref BitbucketVersion]]]
-  ShouldUseES23:
-    !And [Condition: IsVersion5X, !Or [Condition: IsVersionX0, Condition: IsVersionX1, Condition: IsVersionX2, Condition: IsVersionX3, Condition: IsVersionX4, Condition: IsVersionX5, Condition: IsVersionX6]]
   RestoreRDSOrStandby:
     !Or [Condition: RestoreFromRDSSnapshot, Condition: StandbyMode]
   CreateESBucket:
@@ -1034,7 +1032,7 @@ Resources:
         EBSEnabled: true
         VolumeSize: !Ref ElasticsearchNodeVolumeSize
         VolumeType: gp2
-      ElasticsearchVersion: !If [ShouldUseES23, "2.3", "5.5"]
+      ElasticsearchVersion: "6.8"
       ElasticsearchClusterConfig:
         InstanceType: !Ref ElasticsearchInstanceType
       AccessPolicies:


### PR DESCRIPTION
Currently Elasticsearch version 5.5 is installed in Bitbucket via quickstart. This version is not officially supported by Bitbucket server: https://confluence.atlassian.com/bitbucketserver/supported-platforms-776640981.html

The highest version of Elasticsearch which is officially supported by Bitbucket and also is available in aws at the time is version 6.8

Here the list of available versions of Elasticsearch in aws could be found: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/what-is-amazon-elasticsearch-service.html#aes-choosing-version

Test:
1. Create Bitbucket stach using quickstart-bitbucket-dc.template.yaml in cloudformation
2. Observe the stack is created successfully
3. Confirm Elasticsearch version is 6.8
4. Open Bitbucket by browser, add the license and create a repository, do some basic activities
5. Use search to make sure search functionality is working as expected
6. Connect to the node that Bitbucket server is running, navigate to /media/alt/bitbucket/log and make sure in log files there is no error related to elastic search recorded

- Tests are passed!