### PR TITLE
DCD-1168: fix bitbucket license key injection

### DIFF
--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -835,7 +835,7 @@ Resources:
                   - ""
                   - !Sub ["ATL_PRODUCT_VERSION=${BitbucketVersion}", BitbucketVersion: !Ref BitbucketVersion]
                   - !If  [IsBBAdminPasswordProvided, !Sub ["ATL_BB_ADMIN_PASSWORD=${BBAdminPassword}", BBAdminPassword: !Ref BitbucketAdminPassword], !Ref "AWS::NoValue"]
-                  - !If  [IsLicenseKeyProvided, !Sub ["ATL_BB_LICENSEKEY=${LicenseKey}", LicenseKey: !Ref BitbucketLicenseKey], !Ref "AWS::NoValue"]
+                  - !If  [IsLicenseKeyProvided, !Sub ["ATL_BB_LICENSEKEY='${LicenseKey}'", LicenseKey: !Ref BitbucketLicenseKey], !Ref "AWS::NoValue"]
                   - !If  [IsURLProvided, !Sub ["ATL_DATASET_URL=${DatasetURL}", DatasetURL: !Ref BitbucketDatasetURL], !Ref "AWS::NoValue"]
                   - !Sub ["ATL_BB_BASEURL=${BaseURL}", BaseURL: !If [UseCustomDnsName, !Sub ["${HTTP}://${CustomDNSName}", { HTTP: !If [DoSSL, https, http], CustomDNSName: !Ref CustomDnsName }], !Sub ["${HTTP}://${LoadBalancerDNSName}", { HTTP: !If [DoSSL, https, http], LoadBalancerDNSName: !GetAtt LoadBalancer.DNSName }]]]
                   - !Sub ["ATL_PROXY_NAME=${AtlProxyName}", AtlProxyName: !If [UseCustomDnsName, !Ref CustomDnsName, !GetAtt LoadBalancer.DNSName]]


### PR DESCRIPTION
When injecting a license, if you didn't remove the whitespace characters when entering it into cloudformation, the ansible bootstrap script would fail when sourcing `etc/atl`. As a simple fix, I have put single quotations around the license when it's dropped from cloudformation. I've tested this and it worked.