### PR TITLE
Add fine-grained access control for elastic search

### DIFF
--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -23,6 +23,7 @@ tests:
       AvailabilityZones: $[taskcat_genaz_2]
       BitbucketVersion: "6.6.0"
       DBMasterUserPassword: $[taskcat_genpass_10S]
+      ElasticSearchPassword: $[taskcat_genpass_10S]
       BitbucketAdminPassword: "replaced-by-taskcat-override-file"
       AccessCIDR: "10.0.0.0/0"
       DBMultiAZ: "false"

--- a/ci/params/3nodes/quickstart-bitbucket-3nodes.json
+++ b/ci/params/3nodes/quickstart-bitbucket-3nodes.json
@@ -12,6 +12,10 @@
     "ParameterValue": "$[taskcat_genpass_8S]"
   },
   {
+    "ParameterKey": "ElasticSearchPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
     "ParameterKey": "BitbucketAdminPassword",
     "ParameterValue": ""
   },

--- a/ci/params/aurora/quickstart-bitbucket-dc-aurora-params.json
+++ b/ci/params/aurora/quickstart-bitbucket-dc-aurora-params.json
@@ -16,6 +16,10 @@
     "ParameterValue": "$[taskcat_genpass_8S]"
   },
   {
+    "ParameterKey": "ElasticSearchPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
     "ParameterKey": "QSS3BucketName",
     "ParameterValue": "$[taskcat_autobucket]"
   },

--- a/ci/params/automated-setup/quickstart-bitbucket-automated-setup.json
+++ b/ci/params/automated-setup/quickstart-bitbucket-automated-setup.json
@@ -36,6 +36,10 @@
     "ParameterValue": "$[taskcat_genpass_8S]"
   },
   {
+    "ParameterKey": "ElasticSearchPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
     "ParameterKey": "KeyPairName",
     "ParameterValue": "replaced-by-taskcat-override-file"
   },

--- a/ci/params/dbVersions/quickstart-bitbucket-aurora-10.json
+++ b/ci/params/dbVersions/quickstart-bitbucket-aurora-10.json
@@ -36,6 +36,10 @@
     "ParameterValue": "$[taskcat_genpass_8S]"
   },
   {
+    "ParameterKey": "ElasticSearchPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
     "ParameterKey": "KeyPairName",
     "ParameterValue": "replaced-by-taskcat-override-file"
   },

--- a/ci/params/dbVersions/quickstart-bitbucket-aurora-11.json
+++ b/ci/params/dbVersions/quickstart-bitbucket-aurora-11.json
@@ -36,6 +36,10 @@
     "ParameterValue": "$[taskcat_genpass_8S]"
   },
   {
+    "ParameterKey": "ElasticSearchPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
     "ParameterKey": "KeyPairName",
     "ParameterValue": "replaced-by-taskcat-override-file"
   },

--- a/ci/params/dbVersions/quickstart-bitbucket-aurora-12.json
+++ b/ci/params/dbVersions/quickstart-bitbucket-aurora-12.json
@@ -36,6 +36,10 @@
     "ParameterValue": "$[taskcat_genpass_8S]"
   },
   {
+    "ParameterKey": "ElasticSearchPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
     "ParameterKey": "KeyPairName",
     "ParameterValue": "replaced-by-taskcat-override-file"
   },

--- a/ci/params/dbVersions/quickstart-bitbucket-postgres-10.json
+++ b/ci/params/dbVersions/quickstart-bitbucket-postgres-10.json
@@ -32,6 +32,10 @@
     "ParameterValue": "$[taskcat_genpass_8S]"
   },
   {
+    "ParameterKey": "ElasticSearchPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
     "ParameterKey": "KeyPairName",
     "ParameterValue": "replaced-by-taskcat-override-file"
   },

--- a/ci/params/dbVersions/quickstart-bitbucket-postgres-11.json
+++ b/ci/params/dbVersions/quickstart-bitbucket-postgres-11.json
@@ -32,6 +32,10 @@
     "ParameterValue": "$[taskcat_genpass_8S]"
   },
   {
+    "ParameterKey": "ElasticSearchPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
     "ParameterKey": "KeyPairName",
     "ParameterValue": "replaced-by-taskcat-override-file"
   },

--- a/ci/params/dbVersions/quickstart-bitbucket-postgres-12.json
+++ b/ci/params/dbVersions/quickstart-bitbucket-postgres-12.json
@@ -32,6 +32,10 @@
     "ParameterValue": "$[taskcat_genpass_8S]"
   },
   {
+    "ParameterKey": "ElasticSearchPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
     "ParameterKey": "KeyPairName",
     "ParameterValue": "replaced-by-taskcat-override-file"
   },

--- a/ci/params/default/quickstart-bitbucket-default.json
+++ b/ci/params/default/quickstart-bitbucket-default.json
@@ -24,6 +24,10 @@
     "ParameterValue": "$[taskcat_genpass_8S]"
   },
   {
+    "ParameterKey": "ElasticSearchPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
     "ParameterKey": "KeyPairName",
     "ParameterValue": "replaced-by-taskcat-override-file"
   },

--- a/ci/params/insecure-search/quickstart-bitbucket-default.json
+++ b/ci/params/insecure-search/quickstart-bitbucket-default.json
@@ -1,0 +1,50 @@
+[
+  {
+    "ParameterKey": "DBMultiAZ",
+    "ParameterValue": "false"
+  },
+  {
+    "ParameterKey": "DBMasterUserPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
+    "ParameterKey": "BitbucketAdminPassword",
+    "ParameterValue": ""
+  },
+  {
+    "ParameterKey": "CidrBlock",
+    "ParameterValue": "0.0.0.0/0"
+  },
+  {
+    "ParameterKey": "DBIops",
+    "ParameterValue": "1000"
+  },
+  {
+    "ParameterKey": "DBPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
+    "ParameterKey": "KeyPairName",
+    "ParameterValue": "replaced-by-taskcat-override-file"
+  },
+  {
+    "ParameterKey": "ClusterNodeInstanceType",
+    "ParameterValue": "t3.medium"
+  },
+  {
+    "ParameterKey": "DBInstanceClass",
+    "ParameterValue": "db.t3.medium"
+  },
+  {
+    "ParameterKey": "QSS3BucketName",
+    "ParameterValue": "$[taskcat_autobucket]"
+  },
+  {
+    "ParameterKey": "QSS3KeyPrefix",
+    "ParameterValue": "quickstart-atlassian-bitbucket/"
+  },
+  {
+    "ParameterKey": "BastionHostRequired",
+    "ParameterValue": "false"
+  }
+]

--- a/ci/params/insecure-search/taskcat.yml
+++ b/ci/params/insecure-search/taskcat.yml
@@ -1,0 +1,26 @@
+---
+global:
+  qsname: quickstart-atlassian-bitbucket
+  owner: quickstart-eng@amazon.com
+  marketplace-ami: false
+  reporting: true
+  regions:
+    - ap-northeast-1
+    - ap-northeast-2
+    - ap-south-1
+    - ap-southeast-1
+    - ap-southeast-2
+    - eu-central-1
+    - eu-west-1
+    - sa-east-1
+    - us-east-1
+    - us-east-2
+    - us-west-1
+    - us-west-2
+
+tests:
+  BB-10:
+    template_file: quickstart-bitbucket-dc.template.yaml
+    parameter_input: params/insecure-search/quickstart-bitbucket-default.json
+    regions:
+     - us-east-1

--- a/ci/params/jvm-support-opts/quickstart-bitbucket-jvm-support-opts.json
+++ b/ci/params/jvm-support-opts/quickstart-bitbucket-jvm-support-opts.json
@@ -24,6 +24,10 @@
     "ParameterValue": "$[taskcat_genpass_8S]"
   },
   {
+    "ParameterKey": "ElasticSearchPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
     "ParameterKey": "KeyPairName",
     "ParameterValue": "replaced-by-taskcat-override-file"
   },

--- a/ci/params/no-bastion/quickstart-bitbucket-no-bastion.json
+++ b/ci/params/no-bastion/quickstart-bitbucket-no-bastion.json
@@ -32,6 +32,10 @@
     "ParameterValue": "$[taskcat_genpass_8S]"
   },
   {
+    "ParameterKey": "ElasticSearchPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
     "ParameterKey": "BastionHostRequired",
     "ParameterValue": "false"
   },

--- a/ci/params/ssl-and-dns/quickstart-bitbucket-ci-params.json
+++ b/ci/params/ssl-and-dns/quickstart-bitbucket-ci-params.json
@@ -20,6 +20,10 @@
         "ParameterValue": "$[taskcat_genpass_8S]"
     },
     {
+        "ParameterKey": "ElasticSearchPassword",
+        "ParameterValue": "$[taskcat_genpass_8S]"
+      },
+    {
         "ParameterKey": "DBStorage",
         "ParameterValue": "100"
     },

--- a/ci/quickstart-bitbucket-master.json
+++ b/ci/quickstart-bitbucket-master.json
@@ -32,6 +32,10 @@
         "ParameterValue": "$[taskcat_genpass_8S]"
     },
     {
+        "ParameterKey": "ElasticSearchPassword",
+        "ParameterValue": "$[taskcat_genpass_8S]"
+    },
+    {
         "ParameterKey": "KeyPairName",
         "ParameterValue": "replaced-by-taskcat-override-file"
     },

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -483,13 +483,9 @@ Parameters:
     Description: Database storage type
     Type: String
   ElasticSearchPassword:
-    Description: "Password for the elasticsearch master user, the username will be 'bitbucket'. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ + % &"
+    Description: "Password for the elasticsearch master user, the username will be 'bitbucket'. If no password is specified, Bitbucket will authenticate with the elasticsearch cluster using IAM request signing (not recommended)."
     Type: String
-    AllowedPattern: '(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*'
-    ConstraintDescription: 'Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ @ + % &'
     NoEcho: True
-    MaxLength: 128
-    MinLength: 8
   ElasticsearchInstanceType:
     Description: EC2 instance type for the Amazon Elasticsearch service to run on.
     Type: String

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -50,6 +50,7 @@ Metadata:
       - Label:
           default: Elasticsearch
         Parameters:
+          - ElasticSearchPassword
           - ElasticsearchInstanceType
           - ElasticsearchNodeVolumeSize
       - Label:
@@ -147,6 +148,8 @@ Metadata:
         default: SSH key name to use with the repository
       CloudWatchIntegration:
         default: Enable CloudWatch integration
+      ElasticSearchPassword:
+        default: Elasticsearch master user password
       ElasticsearchInstanceType:
         default: Elasticsearch instance type
       ElasticsearchNodeVolumeSize:
@@ -479,6 +482,14 @@ Parameters:
     ConstraintDescription: Must be 'General Purpose (SSD)' or 'Provisioned IOPS'.
     Description: Database storage type
     Type: String
+  ElasticSearchPassword:
+    Description: "Password for the elasticsearch master user, the username will be 'bitbucket'. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ + % &"
+    Type: String
+    AllowedPattern: '(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*'
+    ConstraintDescription: 'Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ @ + % &'
+    NoEcho: True
+    MaxLength: 128
+    MinLength: 8
   ElasticsearchInstanceType:
     Description: EC2 instance type for the Amazon Elasticsearch service to run on.
     Type: String
@@ -710,6 +721,7 @@ Resources:
         DeploymentAutomationKeyName: !Ref 'DeploymentAutomationKeyName'
         DeploymentAutomationCustomParams: !Ref 'DeploymentAutomationCustomParams'
         ExportPrefix: !Ref ExportPrefix
+        ElasticSearchPassword: !Ref ElasticSearchPassword
         ElasticsearchInstanceType: !Ref 'ElasticsearchInstanceType'
         ElasticsearchNodeVolumeSize: !Ref 'ElasticsearchNodeVolumeSize'
         ESBucketName: !Ref 'ESBucketName'

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -149,7 +149,7 @@ Metadata:
       CloudWatchIntegration:
         default: Enable CloudWatch integration
       ElasticSearchPassword:
-        default: Elasticsearch master user password
+        default: Elasticsearch master user password *
       ElasticsearchInstanceType:
         default: Elasticsearch instance type
       ElasticsearchNodeVolumeSize:

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -1050,7 +1050,6 @@ Resources:
           MasterUserPassword: !Ref ElasticSearchPassword
       DomainEndpointOptions:
         EnforceHTTPS: true
-        # Should we enforce TLS 1.2?
         TLSSecurityPolicy: Policy-Min-TLS-1-2-2019-07
       EncryptionAtRestOptions:
         Enabled: true

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -889,6 +889,7 @@ Resources:
                   - !Sub ["ATL_ELASTICSEARCH_HOST=${ESEndpoint}", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
                   - !Sub ["ATL_ELASTICSEARCH_ENDPOINT=https://${ESEndpoint}", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
                   - "ATL_ELASTICSEARCH_USERNAME=bitbucket"
+                  - "ATL_ELASTICSEARCH_PROTOCOL=https"
                   - !Sub ["ATL_ELASTICSEARCH_PASSWORD=${ESPassword}", ESPassword: !Ref ElasticSearchPassword]
                   - !Sub ["ATL_BITBUCKET_PROPERTIES=\"${BitbucketProperties}\"", BitbucketProperties: !Ref BitbucketProperties]
                   - !If [DoSSL, "ATL_SSL_PROXY=true", !Ref "AWS::NoValue"]

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -887,7 +887,6 @@ Resources:
                   - !Sub ["ATL_NFS_DISK_VOLUME_IOPS=${VolIOPs}", VolIOPs: !If [IsHomeProvisionedIops, !Ref "HomeIops", ""]]
                   - ""
                   - !Sub ["ATL_ELASTICSEARCH_HOST=${ESEndpoint}", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
-                  - !Sub ["ATL_ELASTICSEARCH_ENDPOINT=https://${ESEndpoint}", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
                   - "ATL_ELASTICSEARCH_USERNAME=bitbucket"
                   - "ATL_ELASTICSEARCH_PROTOCOL=https"
                   - !Sub ["ATL_ELASTICSEARCH_PASSWORD=${ESPassword}", ESPassword: !Ref ElasticSearchPassword]

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -139,7 +139,7 @@ Metadata:
       CloudWatchIntegration:
         default: Enable CloudWatch integration
       ElasticSearchPassword:
-        default: Elasticsearch master user password
+        default: Elasticsearch master user password *
       ElasticsearchInstanceType:
         default: Elasticsearch instance type
       ElasticsearchNodeVolumeSize:

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -612,6 +612,10 @@ Conditions:
     !Not [!Equals [!Ref CloudWatchIntegration, 'Off']]
   EnableCloudWatchLogs:
     !Equals [!Ref CloudWatchIntegration, 'Metrics and Logs']
+  UseFineGrainedAccessControlES:
+    !Not [!Equals [!Ref ElasticSearchPassword, '']]
+  UseIAMSignedRequestsES:
+    !Equals [!Ref ElasticSearchPassword, '']
   RestoreFromEBSSnapshot:
     !Not [!Equals [!Ref HomeVolumeSnapshotId, '']]
   RestoreFromRDSSnapshot:
@@ -886,10 +890,11 @@ Resources:
                   - !Sub ["ATL_NFS_DISK_VOLUME_TYPE=${VolType}", VolType: !If [IsHomeProvisionedIops, "io1", "gp2"]]
                   - !Sub ["ATL_NFS_DISK_VOLUME_IOPS=${VolIOPs}", VolIOPs: !If [IsHomeProvisionedIops, !Ref "HomeIops", ""]]
                   - ""
-                  - !Sub ["ATL_ELASTICSEARCH_HOST=${ESEndpoint}", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
-                  - "ATL_ELASTICSEARCH_USERNAME=bitbucket"
-                  - "ATL_ELASTICSEARCH_PROTOCOL=https"
-                  - !Sub ["ATL_ELASTICSEARCH_PASSWORD=${ESPassword}", ESPassword: !Ref ElasticSearchPassword]
+                  - !Sub ["ATL_ELASTICSEARCH_HOST=${ESEndpoint}", ESEndpoint: !If [UseFineGrainedAccessControlES, !GetAtt ElasticsearchSecure.DomainEndpoint, !GetAtt Elasticsearch.DomainEndpoint]]
+                  - !Sub ["ATL_ELASTICSEARCH_PROTOCOL=${ESScheme}", ESScheme: !If [UseFineGrainedAccessControlES, "https", "http"]]
+                  - !If [UseFineGrainedAccessControlES, "ATL_ELASTICSEARCH_USERNAME=bitbucket", !Ref "AWS::NoValue"]
+                  - !If [UseFineGrainedAccessControlES, !Sub ["ATL_ELASTICSEARCH_PASSWORD=${ESPassword}", ESPassword: !Ref ElasticSearchPassword], !Ref "AWS::NoValue"]
+                  - ""
                   - !Sub ["ATL_BITBUCKET_PROPERTIES=\"${BitbucketProperties}\"", BitbucketProperties: !Ref BitbucketProperties]
                   - !If [DoSSL, "ATL_SSL_PROXY=true", !Ref "AWS::NoValue"]
 
@@ -1025,6 +1030,31 @@ Resources:
           Value: !Ref ClusterNodeGroup
       ComparisonOperator: LessThanThreshold
   Elasticsearch:
+    Condition: UseIAMSignedRequestsES
+    Type: AWS::Elasticsearch::Domain
+    Properties:
+      EBSOptions:
+        EBSEnabled: true
+        VolumeSize: !Ref ElasticsearchNodeVolumeSize
+        VolumeType: gp2
+      ElasticsearchVersion: "6.8"
+      ElasticsearchClusterConfig:
+        InstanceType: !Ref ElasticsearchInstanceType
+      AccessPolicies:
+        Version: 2012-10-17
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS: !GetAtt BitbucketClusterNodeRole.Arn
+            Action: "es:*"
+            Resource: "*"
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName} Bitbucket Elasticsearch cluster"
+        - Key: Application
+          Value: !Ref "AWS::StackId"
+  ElasticsearchSecure:
+    Condition: UseFineGrainedAccessControlES
     Type: AWS::Elasticsearch::Domain
     Properties:
       EBSOptions:
@@ -1071,6 +1101,7 @@ Resources:
         - Key: Application
           Value: !Ref "AWS::StackId"
   ElasticsearchKMSKey:
+    Condition: UseFineGrainedAccessControlES
     Type: AWS::KMS::Key
     Properties:
       Description: Encryption key for Elasticsearch cluster
@@ -1143,7 +1174,7 @@ Resources:
                   - !Sub ["ATL_NFS_DISK_VOLUME_TYPE=${VolType}", VolType: !If [IsHomeProvisionedIops, "io1", "gp2"]]
                   - !Sub ["ATL_NFS_DISK_VOLUME_IOPS=${VolIOPs}", VolIOPs: !If [IsHomeProvisionedIops, !Ref "HomeIops", ""]]
                   - ""
-                  - !Sub ["ATL_ELASTICSEARCH_HOST=${ESEndpoint}", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
+                  - !Sub ["ATL_ELASTICSEARCH_HOST=${ESEndpoint}", ESEndpoint: !If [UseFineGrainedAccessControlES, !GetAtt ElasticsearchSecure.DomainEndpoint, !GetAtt Elasticsearch.DomainEndpoint]]
                   - !Sub ["ATL_ELASTICSEARCH_S3_BUCKET=${BucketName}", BucketName: !Ref ESBucketName]
                   - !Sub ["ATL_BITBUCKET_PROPERTIES=\"${BitbucketProperties}\"", BitbucketProperties: !Ref BitbucketProperties]
                   - !If [DoSSL, "ATL_SSL_PROXY=true", !Ref "AWS::NoValue"]

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -457,13 +457,9 @@ Parameters:
     Description: Database storage type
     Type: String
   ElasticSearchPassword:
-    Description: "Password for the elasticsearch master user, the username will be 'bitbucket'. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ + % &"
+    Description: "Password for the elasticsearch master user, the username will be 'bitbucket'. If no password is specified, Bitbucket will authenticate with the elasticsearch cluster using IAM request signing (not recommended)."
     Type: String
-    AllowedPattern: '(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*'
-    ConstraintDescription: 'Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ @ + % &'
     NoEcho: True
-    MaxLength: 128
-    MinLength: 8
   ElasticsearchInstanceType:
     Description: EC2 instance type for the Amazon Elasticsearch service to run on.
     Type: String

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -1054,15 +1054,18 @@ Resources:
         TLSSecurityPolicy: Policy-Min-TLS-1-2-2019-07
       EncryptionAtRestOptions:
         Enabled: true
+        KmsKeyId: !Ref ElasticsearchKMSKey
       NodeToNodeEncryptionOptions:
         Enabled: true
-      # VPCOptions:
-      #   SubnetIds:
-      #     - !Select
-      #       - 0
-      #       - !Split
-      #         - ','
-      #         - Fn::ImportValue: !Sub '${ExportPrefix}PriNets'
+      VPCOptions:
+        SubnetIds:
+          - !Select
+            - 0
+            - !Split
+              - ','
+              - Fn::ImportValue: !Sub '${ExportPrefix}PriNets'
+        SecurityGroupIds:
+          - !Ref SecurityGroup
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName} Bitbucket Elasticsearch cluster"

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -50,6 +50,7 @@ Metadata:
       - Label:
           default: Elasticsearch
         Parameters:
+          - ElasticSearchPassword
           - ElasticsearchInstanceType
           - ElasticsearchNodeVolumeSize
       - Label:
@@ -137,6 +138,8 @@ Metadata:
         default: SSH key name to use with the repository
       CloudWatchIntegration:
         default: Enable CloudWatch integration
+      ElasticSearchPassword:
+        default: Elasticsearch master user password
       ElasticsearchInstanceType:
         default: Elasticsearch instance type
       ElasticsearchNodeVolumeSize:
@@ -453,6 +456,14 @@ Parameters:
     ConstraintDescription: Must be 'General Purpose (SSD)' or 'Provisioned IOPS'.
     Description: Database storage type
     Type: String
+  ElasticSearchPassword:
+    Description: "Password for the elastic search master user, the username will be 'bitbucket'. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ + % &"
+    Type: String
+    AllowedPattern: '(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*'
+    ConstraintDescription: 'Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ @ + % &'
+    NoEcho: True
+    MaxLength: 128
+    MinLength: 8
   ElasticsearchInstanceType:
     Description: EC2 instance type for the Amazon Elasticsearch service to run on.
     Type: String
@@ -876,7 +887,9 @@ Resources:
                   - !Sub ["ATL_NFS_DISK_VOLUME_IOPS=${VolIOPs}", VolIOPs: !If [IsHomeProvisionedIops, !Ref "HomeIops", ""]]
                   - ""
                   - !Sub ["ATL_ELASTICSEARCH_HOST=${ESEndpoint}", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
-                  - !Sub ["ATL_ELASTICSEARCH_ENDPOINT=http://${ESEndpoint}", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
+                  - !Sub ["ATL_ELASTICSEARCH_ENDPOINT=https://${ESEndpoint}", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
+                  - "ATL_ELASTICSEARCH_USERNAME=bitbucket"
+                  - !Sub ["ATL_ELASTICSEARCH_PASSWORD=${ESPassword}", ESPassword: !Ref ElasticSearchPassword]
                   - !Sub ["ATL_BITBUCKET_PROPERTIES=\"${BitbucketProperties}\"", BitbucketProperties: !Ref BitbucketProperties]
                   - !If [DoSSL, "ATL_SSL_PROXY=true", !Ref "AWS::NoValue"]
 
@@ -1026,14 +1039,54 @@ Resources:
         Statement:
           - Effect: "Allow"
             Principal:
-              AWS: !GetAtt BitbucketClusterNodeRole.Arn
-            Action: "es:*"
+              AWS: "*"
+            Action: "es:ESHttp*"
             Resource: "*"
+      AdvancedSecurityOptions:
+        Enabled: true
+        InternalUserDatabaseEnabled: true
+        MasterUserOptions:
+          MasterUserName: bitbucket
+          MasterUserPassword: !Ref ElasticSearchPassword
+      DomainEndpointOptions:
+        EnforceHTTPS: true
+        # Should we enforce TLS 1.2?
+        TLSSecurityPolicy: Policy-Min-TLS-1-2-2019-07
+      EncryptionAtRestOptions:
+        Enabled: true
+      NodeToNodeEncryptionOptions:
+        Enabled: true
+      # VPCOptions:
+      #   SubnetIds:
+      #     - !Select
+      #       - 0
+      #       - !Split
+      #         - ','
+      #         - Fn::ImportValue: !Sub '${ExportPrefix}PriNets'
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName} Bitbucket Elasticsearch cluster"
         - Key: Application
           Value: !Ref "AWS::StackId"
+  ElasticsearchKMSKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: Encryption key for Elasticsearch cluster
+      Enabled: true
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Id: !Sub "${AWS::StackName}"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS:
+                - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"
+            Action: 'kms:*'
+            Resource: '*'
+      Tags:
+        - Key: Name
+          Value: !Sub ["${StackName} Elasticsearch Encryption Key", StackName: !Ref 'AWS::StackName']
   ElasticsearchBucket:
     Type: AWS::S3::Bucket
     Condition: CreateESBucket

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -457,7 +457,7 @@ Parameters:
     Description: Database storage type
     Type: String
   ElasticSearchPassword:
-    Description: "Password for the elastic search master user, the username will be 'bitbucket'. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ + % &"
+    Description: "Password for the elasticsearch master user, the username will be 'bitbucket'. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ + % &"
     Type: String
     AllowedPattern: '(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*'
     ConstraintDescription: 'Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, and 1 of the following symbols: ! # $ { * : [ = , ] - _ @ + % &'


### PR DESCRIPTION
This gets rid of AWS IAM signed requests and instead forces basic authentication over HTTPS. Other required side-effects:

* Encryption at rest
* Node to node encryption
* Forced HTTPS
* Deploy Elasticsearch domain in the product VPC

![image](https://user-images.githubusercontent.com/21027663/108463562-b9276f00-72d2-11eb-9c37-f6d4a599fc9f.png)

---
This requires changes to dc-deployments-automation raised here: https://bitbucket.org/atlassian/dc-deployments-automation/pull-requests/132/dcd-1157-add-properties-for-elasticsearch