### PR TITLE
DCD-1251: Add ElasticSearch service role

### DIFF
--- a/ci/params/insecure-search/quickstart-bitbucket-default.json
+++ b/ci/params/insecure-search/quickstart-bitbucket-default.json
@@ -46,5 +46,9 @@
   {
     "ParameterKey": "BastionHostRequired",
     "ParameterValue": "false"
+  },
+  {
+    "ParameterKey": "ElasticSearchPassword",
+    "ParameterValue": ""
   }
 ]

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -825,10 +825,10 @@ Resources:
           PropagateAtLaunch: true
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 0bf6c6529a5a50615a055dcb2cb6840b519bf926"
+          Value: "COMMIT: 13f126a1c0f37984f5dd74d4538bcb398abe880e"
           PropagateAtLaunch: true
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2021-02-16T00:09:16Z"
+          Value: "TIMESTAMP: 2021-04-01T01:22:19Z"
           PropagateAtLaunch: true
   ClusterNodeLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
@@ -1049,8 +1049,15 @@ Resources:
           Value: !Sub "${AWS::StackName} Bitbucket Elasticsearch cluster"
         - Key: Application
           Value: !Ref "AWS::StackId"
+  ElasticsearchServiceRole:
+    Condition: UseFineGrainedAccessControlES
+    Type: AWS::IAM::ServiceLinkedRole
+    Properties:
+      AWSServiceName: "es.amazonaws.com"
   ElasticsearchSecure:
     Condition: UseFineGrainedAccessControlES
+    DependsOn:
+      - ElasticsearchServiceRole
     Type: AWS::Elasticsearch::Domain
     Properties:
       EBSOptions:


### PR DESCRIPTION
If a customer has ever worked with Elasticsearch via AWS console, they have the Elasticsearch service role created. If they didn't we will fail to create the CloudFormation stack as the Elasticsearch domain created via CloudFormation won't create the service role the same way as AWS console does.

I have tested this for secured (with ES password) and unsecured (without ES password) and both stacks were created. I still think this deserves more testing.

Notes:
- Elasticsearch service role doesn't support `CustomSuffix` - the stack will fail if there is a suffix
- In case the role is already there, the `Description` needs to be the same - by default the Description is `''` - empty string, so this is the reason why we don't include `Description` parameter for the service role object

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-servicelinkedrole.html