### PR TITLE
Use NoEcho parameter property for BitbucketLicenseKey 

### DIFF
--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -211,6 +211,7 @@ Parameters:
   BitbucketLicenseKey:
     Default: ''
     Description: Provide a license key for Bitbucket Data Center if you have one.
+    NoEcho: true
     Type: String
   BitbucketAdminPassword:
     AllowedPattern: '((?=^.{0,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*)|(^$)'

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -193,6 +193,7 @@ Parameters:
   BitbucketLicenseKey:
     Default: ''
     Description: (Optional) Provide a license key for Bitbucket Data Center if you have one.
+    NoEcho: true
     Type: String
   BitbucketAdminPassword:
     AllowedPattern: '((?=^.{0,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*)|(^$)'


### PR DESCRIPTION
Use NoEcho parameter property for BitbucketLicenseKey to avoid a reflect it as plaintext in console