### PR TITLE
DCD-1300: Fix ARN partition for lambda function

### DIFF
--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -203,7 +203,7 @@ Parameters:
     Description: A space-separated list of bitbucket properties in the form 'key1=value1 key2=value2 ...' Find documentation at https://confluence.atlassian.com/x/m5ZKLg
     Type: String
   BitbucketVersion:
-    Default: "7.6.5"
+    Default: "7.6.7"
     AllowedPattern: '([^1234]\.\d+\.\d+(-?.*))'
     ConstraintDescription: 'Must be a valid Bitbucket version number. For example: 5.0.0 or higher'
     Description: 'Version of Bitbucket to install. Please use version 5.0.0 or higher. Find valid versions at http://go.atlassian.com/bbs-releases'

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -185,7 +185,7 @@ Parameters:
     Description: A space-separated list of bitbucket properties in the form 'key1=value1 key2=value2 ...' Find documentation at https://confluence.atlassian.com/x/m5ZKLg
     Type: String
   BitbucketVersion:
-    Default: "7.6.5"
+    Default: "7.6.7"
     AllowedPattern: '([^1234]\.\d+\.\d+(-?.*))'
     ConstraintDescription: 'Must be a valid Bitbucket version number. For example: 5.0.0 or higher'
     Description: 'Version of Bitbucket to install. Please use version 5.0.0 or higher. Find valid versions at http://go.atlassian.com/bbs-releases'
@@ -826,10 +826,10 @@ Resources:
           PropagateAtLaunch: true
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: d190f41ada2562f76573e0951648996bae6c557f"
+          Value: "COMMIT: 42c34d27a469d9fe06cb494ee8b10ae208e51814"
           PropagateAtLaunch: true
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2021-04-07T02:02:17Z"
+          Value: "TIMESTAMP: 2021-06-07T23:50:53Z"
           PropagateAtLaunch: true
   ClusterNodeLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
@@ -1344,7 +1344,7 @@ Resources:
             - logs:CreateLogGroup
             - logs:CreateLogStream
             - logs:PutLogEvents
-            Resource: !Sub "arn:aws:logs:*:${AWS::AccountId}:log-group:/aws/lambda/*DBNameGenerator*"
+            Resource: !Sub "arn:${AWS::Partition}:logs:*:${AWS::AccountId}:log-group:/aws/lambda/*DBNameGenerator*"
   DB:
     Type: AWS::RDS::DBInstance
     Condition: DBEnginePostgres


### PR DESCRIPTION
Bitbucket deployment was failing on GovCloud due to the lambda ARN not including the correct partition identifier.

* Fix the ARN for lambda function
* Update to latest LTS 7.6.7