### PR TITLE
DCD-1459 Upgraded AMIs for the AWS quickstarts

### DIFF
--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -657,37 +657,37 @@ Conditions:
 Mappings:
   AWSRegionArch2AMI:
     ap-northeast-1:
-      HVM64: ami-0c3fd0f5d33134a76
+      HVM64: ami-08d56ac42e2d4a08b
     ap-northeast-2:
-      HVM64: ami-095ca789e0549777d
+      HVM64: ami-0eb7a369386789460
     ap-south-1:
-      HVM64: ami-0d2692b6acea72ee6
+      HVM64: ami-0dafa01c8100180f8
     ap-southeast-1:
-      HVM64: ami-01f7527546b557442
+      HVM64: ami-04fc979a55e14b094
     ap-southeast-2:
-      HVM64: ami-0dc96254d5535925f
+      HVM64: ami-042c4533fa25c105a
     ca-central-1:
-      HVM64: ami-0d4ae09ec9361d8ac
+      HVM64: ami-040d8c460f4fc4a9f
     eu-central-1:
-      HVM64: ami-0cc293023f983ed53
+      HVM64: ami-00e232b942edaf8f9
     eu-north-1:
-      HVM64: ami-3f36be41
+      HVM64: ami-0e3f1570eb0a9bc7f
     eu-west-1:
-      HVM64: ami-0bbc25e23a7640b9b
+      HVM64: ami-09d5dd12541e69077
     eu-west-2:
-      HVM64: ami-0d8e27447ec2c8410
+      HVM64: ami-098a393b6fa6e700b
     eu-west-3:
-      HVM64: ami-0adcddd3324248c4c
+      HVM64: ami-05cb6b584fc3c8ac8
     sa-east-1:
-      HVM64: ami-058943e7d9b9cabfb
+      HVM64: ami-088911543b10876a4
     us-east-1:
-      HVM64: ami-0b898040803850657
+      HVM64: ami-038b3df3312ddf25d
     us-east-2:
-      HVM64: ami-0d8f6eb4f641ef691
+      HVM64: ami-07b1d7739c91ed3fc
     us-west-1:
-      HVM64: ami-056ee704806822732
+      HVM64: ami-0729cd65c1a99b0c9
     us-west-2:
-      HVM64: ami-082b5a644766e0e6f
+      HVM64: ami-090bc08d7ae1f3881
     us-gov-west-1:
       HVM64: ami-e9a9d388
     us-gov-east-1:


### PR DESCRIPTION
DCD-1459 Upgraded AMIs for the AWS quickstarts
Updated AMIs to use latest Amazon Linux 2 amzn2-ami-hvm-2.0.20220207.1-x86_64-gp2 for Bitbucket