### PR TITLE
DCD-956 Creation policy to wait until all the instances are up and running

### DIFF
--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -920,6 +920,10 @@ Resources:
       Roles: [!Ref BitbucketClusterNodeRole]
   ClusterNodeGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
+    CreationPolicy:
+      ResourceSignal:
+        Count: !Ref ClusterNodeMin
+        Timeout: PT15M
     Properties:
       DesiredCapacity: !If [StandbyMode, '0', !Ref ClusterNodeMin]
       LaunchConfigurationName: !Ref ClusterNodeLaunchConfig


### PR DESCRIPTION
DCD-956 Creation policy to wait until all the instances are up and running