### PR TITLE
CLIP-1637 Bumped ElasticSearch version to 7.16.3 in Bitbucket

### DIFF
--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -1153,7 +1153,7 @@ Resources:
         EBSEnabled: true
         VolumeSize: !Ref ElasticsearchNodeVolumeSize
         VolumeType: gp2
-      ElasticsearchVersion: "6.8"
+      ElasticsearchVersion: "7.16.3"
       ElasticsearchClusterConfig:
         InstanceType: !Ref ElasticsearchInstanceType
       AccessPolicies:


### PR DESCRIPTION
CLIP-1637

Bumped ElasticSearch version to 7.16.3 in Bitbucket
